### PR TITLE
fix: show gift card, if applied, in payment overview

### DIFF
--- a/src/domain/orders/details/index.js
+++ b/src/domain/orders/details/index.js
@@ -650,6 +650,11 @@ const OrderDetails = ({ id }) => {
                   Discount
                 </Text>
               )}
+              {order.gift_card_total > 0 && (
+                <Text pt={1} color="gray">
+                  Gift card(s)
+                </Text>
+              )}
               <Text pt={1} color="gray">
                 Total
               </Text>
@@ -675,6 +680,14 @@ const OrderDetails = ({ id }) => {
                   <AlignedDecimal
                     currency={order.currency_code}
                     value={-order.discount_total * (1 + order.tax_rate / 100)}
+                  />
+                </Text>
+              )}
+              {order.gift_card_total > 0 && (
+                <Text pt={1}>
+                  <AlignedDecimal
+                    currency={order.currency_code}
+                    value={-order.gift_card_total * (1 + order.tax_rate / 100)}
                   />
                 </Text>
               )}


### PR DESCRIPTION
### What?

- When showing details of an order, if any gift cards are applied, the gift card(s) amount total should be shown in payment overview.

### Why?

- Provides more details/insights on orders to admins.

### How?

- Conditional rendering: when `gift_card_total > 0`, display the gift_card_total, else ignore.