### PR TITLE
fix: Edit shipping options requirements

### DIFF
--- a/src/domain/settings/regions/edit-shipping.js
+++ b/src/domain/settings/regions/edit-shipping.js
@@ -100,6 +100,11 @@ const EditShipping = ({ shippingOption, region, onDone, onClick }) => {
               amount: Math.round(value.amount * 100),
               id: reqType.id,
             })
+          } else {
+            acc.push({
+              type: key,
+              amount: Math.round(value.amount * 100),
+            })
           }
           return acc
         } else {


### PR DESCRIPTION
**What**
- Allows to update a `Shipping Option` with new requirements, even if it had no prior requirements

**Why**
- It should be optional whether to add requirements to a `Shipping Option` and then possible to add requirements later, even if it was created without any.

**Note**
Dependency of [#340](https://github.com/medusajs/medusa/pull/340) in Medusa Core to take effect before the change will be supported.