### PR TITLE
multiply value with 100 to convert to whole number percentage

### DIFF
--- a/src/domain/settings/regions/new.js
+++ b/src/domain/settings/regions/new.js
@@ -81,9 +81,11 @@ const NewRegion = ({ id }) => {
   }
 
   const onSave = data => {
-    Medusa.regions.create(data).then(({ data }) => {
-      navigate(`/a/settings`)
-    })
+    Medusa.regions
+      .create({ ...data, tax_rate: data.tax_rate * 100 })
+      .then(() => {
+        navigate(`/a/settings`)
+      })
   }
 
   const countryOptions = countryData.map(c => ({
@@ -131,6 +133,9 @@ const NewRegion = ({ id }) => {
           min={0}
           max={1}
           width="75%"
+          placeholder={
+            "A percentage given as a decimal number between 0 and 1."
+          }
           name="tax_rate"
           label="Tax Rate"
           ref={register}


### PR DESCRIPTION
### What
Multiplies tax_rate with 100 to convert to whole number percentage

### Why
The database saves percentages with a value between 0-100, so to visually show it as a decimal number, we have to account for this before we call the create endpoint

### How
Multiplies tax_rate with 100 when calling the `create` endpoint