### PR TITLE
Bug: include denominations on giftcard creation

### DIFF
--- a/src/domain/gift-cards/manage/index.js
+++ b/src/domain/gift-cards/manage/index.js
@@ -159,7 +159,7 @@ const NewGiftCard = ({}) => {
       <Text mb={4}>Denominations</Text>
       <Flex mb={5} flexDirection="column">
         {fields.map((d, index) => (
-          <Flex mb={5} key={d.id}>
+          <Flex mb={3} key={d.id}>
             <Input
               type="number"
               name={`denominations.${index}`}

--- a/src/domain/gift-cards/manage/index.js
+++ b/src/domain/gift-cards/manage/index.js
@@ -14,6 +14,7 @@ import Medusa from "../../../services/api"
 import useMedusa from "../../../hooks/use-medusa"
 
 import GiftCardDetail from "./detail"
+import { persistedPrice } from "../../../utils/prices"
 
 const Cross = styled.span`
   position: absolute;
@@ -106,7 +107,8 @@ const NewGiftCard = ({}) => {
 
     product.variants.forEach(variant => {
       variant.prices.forEach(
-        price => (price.amount = Math.round(price.amount * 100))
+        price =>
+          (price.amount = persistedPrice(price.currency_code, price.amount))
       )
     })
 

--- a/src/domain/gift-cards/manage/index.js
+++ b/src/domain/gift-cards/manage/index.js
@@ -103,8 +103,15 @@ const NewGiftCard = ({}) => {
 
   const submit = data => {
     const product = parseProduct(data)
+
+    product.variants.forEach(variant => {
+      variant.prices.forEach(
+        price => (price.amount = Math.round(price.amount * 100))
+      )
+    })
+
     Medusa.products.create(product).then(({ data }) => {
-      navigate(`/a/products/${data.product._id}`)
+      navigate(`/a/products/${data.product.id}`)
     })
   }
 
@@ -152,10 +159,10 @@ const NewGiftCard = ({}) => {
       <Text mb={4}>Denominations</Text>
       <Flex mb={5} flexDirection="column">
         {fields.map((d, index) => (
-          <Flex mb={3}>
+          <Flex mb={5} key={d.id}>
             <Input
               type="number"
-              name={`denominations[${index}]`}
+              name={`denominations.${index}`}
               label="Value (Default Currency)"
               ref={register}
             />

--- a/src/utils/prices.js
+++ b/src/utils/prices.js
@@ -53,3 +53,12 @@ export const extractOptionPrice = (price, region) => {
   amount = (amount * (1 + region.tax_rate / 100)) / 100
   return `${amount} ${region.currency_code.toUpperCase()}`
 }
+
+export function persistedPrice(currency, amount) {
+  let multiplier = 100
+  if (noDivisionCurrencies.includes(currency.toLowerCase())) {
+    multiplier = 1
+  }
+
+  return Math.floor(amount) * multiplier
+}


### PR DESCRIPTION
**What?**
- Correct denomination creation for giftcards
- Routing to product page of giftcards after creation
- Adjusted denomination amount to reflect the decimal representation of prices in the database

**Why?**
- Giftcard creation crashed previously
- After creation the client navigated to `product/undefined`

**How?**
- Changed field name to use object notation for index as described in useFieldArray documentation
- Included a key for each denomination
- Created a util method for price calculation when sending data to the database for easy inclusion of additional 'no division currencies' or later changes to price calculations
