### PR TITLE
Bug/default currency for giftcards

### DIFF
--- a/src/domain/gift-cards/manage/detail.js
+++ b/src/domain/gift-cards/manage/detail.js
@@ -7,6 +7,7 @@ import { navigate } from "gatsby"
 import Information from "../../products/details/information"
 import Images from "../../products/details/images"
 
+import { displayAmount } from "../../../utils/prices"
 import useMedusa from "../../../hooks/use-medusa"
 import NotFound from "../../../components/not-found"
 import Card from "../../../components/card"
@@ -122,7 +123,10 @@ const GiftCardDetail = ({ id }) => {
                   {v.prices
                     .map(
                       ({ currency_code, amount }) =>
-                        `${amount / 100} ${currency_code.toUpperCase()}`
+                        `${displayAmount(
+                          currency_code,
+                          amount
+                        )} ${currency_code.toUpperCase()}`
                     )
                     .join(", ")}
                 </Box>

--- a/src/domain/gift-cards/manage/index.js
+++ b/src/domain/gift-cards/manage/index.js
@@ -70,6 +70,7 @@ const StyledImageBox = styled(Flex)`
 
 const NewGiftCard = ({}) => {
   const [images, setImages] = useState([])
+  const { store } = useMedusa("store")
   const { control, register, handleSubmit, reset, setValue } = useForm({
     defaultValues: {
       title: "Gift Card",
@@ -92,7 +93,7 @@ const NewGiftCard = ({}) => {
         title: `${index + 1}`,
         prices: [
           {
-            currency_code: "DKK",
+            currency_code: store.default_currency_code,
             amount: v,
           },
         ],


### PR DESCRIPTION
**What?** 
- Set currency correctly for giftcard creation according to store settings
- Add display price calculation to account for no division currencies

**Why?**
- Currency was locked in to DKK when creating a giftcard 
- Display price calculation assists with uniform price calculation for the frontend
