### PR TITLE
Fix/update variant modal correctly passes

### DIFF
--- a/src/components/variant-grid/index.js
+++ b/src/components/variant-grid/index.js
@@ -248,98 +248,102 @@ const VariantGrid = ({ product, variants, onChange, edit, onEdit, onCopy }) => {
           </tr>
         </TableHead>
         <tbody>
-          {variants.map((v, row) => (
-            <tr key={row}>
-              {columns.map((c, col) => (
-                <Td
-                  key={`${row}-${col}`}
-                  data-col={col}
-                  data-row={row}
-                  dragover={isDraggedOver({ col, row })}
-                  onDragEnter={handleDragEnter}
-                  onClick={() =>
-                    !c.readOnly &&
-                    setSelectedCell({
-                      field: c.field,
-                      value: v[c.field],
-                      row,
-                      col,
-                    })
-                  }
-                  selected={
-                    selectedCell.row === row && selectedCell.col === col
-                  }
-                  head={c.headCol}
-                >
-                  {!(selectedCell.row === row && selectedCell.col === col) &&
-                    getDisplayValue(v, c, isDraggedOver({ col, row }))}
-                  {selectedCell.row === row && selectedCell.col === col && (
-                    <>
-                      <GridEditor
-                        ref={setRef}
-                        column={c}
-                        index={row}
-                        value={v[c.field]}
-                        onKeyDown={handleKey}
-                        onChange={handleChange}
-                      />
-                      <DragHandle draggable onDragEnd={handleDragEnd} />
-                    </>
+          {variants.map(
+            (v, row) =>
+              v.id !== undefined && (
+                <tr key={row}>
+                  {columns.map((c, col) => (
+                    <Td
+                      key={`${row}-${col}`}
+                      data-col={col}
+                      data-row={row}
+                      dragover={isDraggedOver({ col, row })}
+                      onDragEnter={handleDragEnter}
+                      onClick={() =>
+                        !c.readOnly &&
+                        setSelectedCell({
+                          field: c.field,
+                          value: v[c.field],
+                          row,
+                          col,
+                        })
+                      }
+                      selected={
+                        selectedCell.row === row && selectedCell.col === col
+                      }
+                      head={c.headCol}
+                    >
+                      {!(
+                        selectedCell.row === row && selectedCell.col === col
+                      ) && getDisplayValue(v, c, isDraggedOver({ col, row }))}
+                      {selectedCell.row === row && selectedCell.col === col && (
+                        <>
+                          <GridEditor
+                            ref={setRef}
+                            column={c}
+                            index={row}
+                            value={v[c.field]}
+                            onKeyDown={handleKey}
+                            onChange={handleChange}
+                          />
+                          <DragHandle draggable onDragEnd={handleDragEnd} />
+                        </>
+                      )}
+                    </Td>
+                  ))}
+                  {onEdit ? (
+                    <Box
+                      as="td"
+                      sx={{
+                        padding: "4px",
+                        borderBottom: "1px solid rgba(0,0,0,0.2)",
+                        backgroundColor: "white",
+                        // position: "sticky !important",
+                        right: 0,
+                      }}
+                    >
+                      <Dropdown
+                        minHeight="24px"
+                        dropdownWidth="120px"
+                        width="28px"
+                        sx={{
+                          height: 0,
+                          padding: 0,
+                          margin: "auto 0 auto auto",
+                        }}
+                      >
+                        <Flex
+                          sx={{ padding: "8px 12px !important" }}
+                          alignItems="center"
+                          onClick={() => onEdit(row)}
+                        >
+                          <EditIcon />
+                          <Text ml={1} fontSize={14}>
+                            Edit
+                          </Text>
+                        </Flex>
+                        <Flex
+                          sx={{ padding: "8px 12px !important" }}
+                          alignItems="center"
+                          onClick={() => onCopy(row)}
+                        >
+                          <ClipboardIcon />
+                          <Text ml={1} fontSize={14}>
+                            Copy
+                          </Text>
+                        </Flex>
+                      </Dropdown>
+                    </Box>
+                  ) : (
+                    <Box
+                      as="td"
+                      height="24px"
+                      sx={{ borderBottom: "1px solid rgba(0,0,0,0.2)" }}
+                    />
                   )}
-                </Td>
-              ))}
-              {onEdit ? (
-                <Box
-                  as="td"
-                  sx={{
-                    padding: "4px",
-                    borderBottom: "1px solid rgba(0,0,0,0.2)",
-                    backgroundColor: "white",
-                    // position: "sticky !important",
-                    right: 0,
-                  }}
-                >
-                  <Dropdown
-                    minHeight="24px"
-                    dropdownWidth="120px"
-                    width="28px"
-                    sx={{
-                      height: 0,
-                      padding: 0,
-                      margin: "auto 0 auto auto",
-                    }}
-                  >
-                    <Flex
-                      sx={{ padding: "8px 12px !important" }}
-                      alignItems="center"
-                      onClick={() => onEdit(row)}
-                    >
-                      <EditIcon />
-                      <Text ml={1} fontSize={14}>
-                        Edit
-                      </Text>
-                    </Flex>
-                    <Flex
-                      sx={{ padding: "8px 12px !important" }}
-                      alignItems="center"
-                      onClick={() => onCopy(row)}
-                    >
-                      <ClipboardIcon />
-                      <Text ml={1} fontSize={14}>
-                        Copy
-                      </Text>
-                    </Flex>
-                  </Dropdown>
-                </Box>
-              ) : (
-                <Box
-                  as="td"
-                  height="24px"
-                  sx={{ borderBottom: "1px solid rgba(0,0,0,0.2)" }}
-                />
-              )}
-            </tr>
-          ))}
+                </tr>
+              )
+          )}
         </tbody>
       </StyledTable>
     </Wrapper>

--- a/src/domain/products/details/variants/index.js
+++ b/src/domain/products/details/variants/index.js
@@ -41,7 +41,7 @@ const Variants = ({
   const dropdownOptions = [
     {
       label: "Add variant",
-      onClick: () => {
+      onClick: () =>
         setVariants([
           ...variants,
           {
@@ -52,8 +52,7 @@ const Variants = ({
             })),
             prices: [],
           },
-        ])
-      },
+        ]),
     },
     {
       label: "Edit options...",

--- a/src/domain/products/details/variants/index.js
+++ b/src/domain/products/details/variants/index.js
@@ -41,7 +41,7 @@ const Variants = ({
   const dropdownOptions = [
     {
       label: "Add variant",
-      onClick: () =>
+      onClick: () => {
         setVariants([
           ...variants,
           {
@@ -52,7 +52,8 @@ const Variants = ({
             })),
             prices: [],
           },
-        ]),
+        ])
+      },
     },
     {
       label: "Edit options...",
@@ -61,6 +62,15 @@ const Variants = ({
       },
     },
   ]
+
+  useEffect(() => {
+    if (
+      variants &&
+      variants[0] &&
+      variants[variants.length - 1].id === undefined
+    )
+      setNewVariant(variants[variants.length - 1])
+  }, [variants])
 
   const handleSubmit = e => {
     e.preventDefault()
@@ -134,8 +144,8 @@ const Variants = ({
     variantMethods
       .update(editVariant.id, cleanedData)
       .then(res => {
-        setEditVariant(null)
         setNewVariant(null)
+        setEditVariant(null)
         toaster("Successfully updated variant", "success")
       })
       .catch(() => toaster("Failed to update variant", "error"))
@@ -210,6 +220,9 @@ const Variants = ({
             else if (editVariant) handleUpdateVariant(data)
           }}
           onClick={() => {
+            if (newVariant) {
+              setVariants([...variants.slice(0, -1)])
+            }
             setEditVariant(null)
             setNewVariant(null)
           }}

--- a/src/domain/products/details/variants/variant-editor.js
+++ b/src/domain/products/details/variants/variant-editor.js
@@ -372,7 +372,7 @@ const VariantEditor = ({
             Cancel
           </Button>
           <Button type="submit" variant="deep-blue">
-            Save
+            {isCopy ? "Create" : "Save"}
           </Button>
         </Modal.Footer>
       </Modal.Body>


### PR DESCRIPTION
### What
- Allow users to create new variants (also automatically show the creation window once user clicks ‘add variant’)

### Why
- This was currently not functioning, but intended to.

### How
- Reuse existing code which allows to add copies of variants (worked fine). 

### Testing
- User testing
