### PR TITLE
Bug:order timeline item inconsistencies

### DIFF
--- a/src/domain/orders/details/claim/create.js
+++ b/src/domain/orders/details/claim/create.js
@@ -13,6 +13,7 @@ import TextArea from "../../../../components/textarea"
 import Select from "../../../../components/select"
 import AddressForm from "../address-form"
 import Medusa from "../../../../services/api"
+import { filterItems } from "../utils/create-filtering"
 
 import { ReactComponent as Trash } from "../../../../assets/svg/trash.svg"
 import { ReactComponent as Edit } from "../../../../assets/svg/edit.svg"
@@ -123,6 +124,8 @@ const ClaimMenu = ({ order, onCreate, onDismiss, toaster }) => {
   // Includes both order items and swap items
   const [allItems, setAllItems] = useState([])
 
+  console.log(order)
+
   const addressForm = useForm()
 
   const handleSaveAddress = data => {
@@ -167,15 +170,7 @@ const ClaimMenu = ({ order, onCreate, onDismiss, toaster }) => {
 
   useEffect(() => {
     if (order) {
-      let temp = [...order.items]
-
-      if (order.swaps && order.swaps.length) {
-        for (const s of order.swaps) {
-          temp = [...temp, ...s.additional_items]
-        }
-      }
-
-      setAllItems(temp)
+      setAllItems(filterItems(order, true))
     }
   }, [order])
 

--- a/src/domain/orders/details/claim/create.js
+++ b/src/domain/orders/details/claim/create.js
@@ -124,8 +124,6 @@ const ClaimMenu = ({ order, onCreate, onDismiss, toaster }) => {
   // Includes both order items and swap items
   const [allItems, setAllItems] = useState([])
 
-  console.log(order)
-
   const addressForm = useForm()
 
   const handleSaveAddress = data => {

--- a/src/domain/orders/details/returns/index.js
+++ b/src/domain/orders/details/returns/index.js
@@ -9,6 +9,7 @@ import Input from "../../../../components/input"
 import Button from "../../../../components/button"
 import Select from "../../../../components/select"
 import Medusa from "../../../../services/api"
+import { filterItems } from "../utils/create-filtering"
 
 const ReturnMenu = ({ order, onReturn, onDismiss, toaster }) => {
   const [submitting, setSubmitting] = useState(false)
@@ -31,15 +32,7 @@ const ReturnMenu = ({ order, onReturn, onDismiss, toaster }) => {
 
   useEffect(() => {
     if (order) {
-      let temp = [...order.items]
-
-      if (order.swaps && order.swaps.length) {
-        for (const s of order.swaps) {
-          temp = [...temp, ...s.additional_items]
-        }
-      }
-
-      setAllItems(temp)
+      setAllItems(filterItems(order, false))
     }
   }, [order])
 

--- a/src/domain/orders/details/swap/create.js
+++ b/src/domain/orders/details/swap/create.js
@@ -12,6 +12,7 @@ import Dropdown from "../../../../components/dropdown"
 import Select from "../../../../components/select"
 import Typography from "../../../../components/typography"
 import Medusa from "../../../../services/api"
+import { filterItems } from "../utils/create-filtering"
 
 const Dot = styled(Box)`
   width: 6px;
@@ -94,15 +95,7 @@ const SwapMenu = ({ order, onCreate, onDismiss, toaster }) => {
 
   useEffect(() => {
     if (order) {
-      let temp = [...order.items]
-
-      if (order.swaps && order.swaps.length) {
-        for (const s of order.swaps) {
-          temp = [...temp, ...s.additional_items]
-        }
-      }
-
-      setAllItems(temp)
+      setAllItems(filterItems(order, false))
     }
   }, [order])
 

--- a/src/domain/orders/details/utils/create-filtering.js
+++ b/src/domain/orders/details/utils/create-filtering.js
@@ -1,14 +1,17 @@
-export const filterItems = (order, is_claim) => {
-  let tmpp = order.items.reduce(
-    (map, obj) => map.set(obj.id, { ...obj }),
+export const filterItems = (order, isClaim) => {
+  let orderItems = order.items.reduce(
+    (map, obj) =>
+      map.set(obj.id, {
+        ...obj,
+      }),
     new Map()
   )
 
-  let claim_items = []
+  let claimItems = []
 
   if (order.claims && order.claims.length) {
     for (const s of order.claims) {
-      claim_items = [...claim_items, ...s.claim_items]
+      claimItems = [...claimItems, ...s.claim_items]
 
       //
       //    Ticket is created to allow claims and swaps on claims and swaps without errors
@@ -21,34 +24,37 @@ export const filterItems = (order, is_claim) => {
       //   }
 
       //   if (s.additional_items && s.additional_items.length)
-      //     tmpp = s.additional_items
+      //     orderItems = s.additional_items
       //       .filter(
       //         it =>
       //           it.shipped_quantity ||
       //           it.shipped_quantity === it.fulfilled_quantity
       //       )
-      //       .reduce((map, obj) => map.set(obj.id, { ...obj }), tmpp)
+      //       .reduce((map, obj) => map.set(obj.id, { ...obj }), orderItems)
     }
   }
 
-  if (!is_claim) {
+  if (!isClaim) {
     if (order.swaps && order.swaps.length) {
       for (const s of order.swaps) {
-        tmpp = s.additional_items.reduce(
-          (map, obj) => map.set(obj.id, { ...obj }),
-          tmpp
+        orderItems = s.additional_items.reduce(
+          (map, obj) =>
+            map.set(obj.id, {
+              ...obj,
+            }),
+          orderItems
         )
       }
     }
   }
 
-  for (const item of claim_items) {
-    let i = tmpp.get(item.item_id)
+  for (const item of claimItems) {
+    let i = orderItems.get(item.item_id)
     if (i) {
       i.quantity = i.quantity - item.quantity
-      i.quantity !== 0 ? tmpp.set(i.id, i) : tmpp.delete(i.id)
+      i.quantity !== 0 ? orderItems.set(i.id, i) : orderItems.delete(i.id)
     }
   }
 
-  return [...tmpp.values()]
+  return [...orderItems.values()]
 }

--- a/src/domain/orders/details/utils/create-filtering.js
+++ b/src/domain/orders/details/utils/create-filtering.js
@@ -7,11 +7,11 @@ export const filterItems = (order, isClaim) => {
     new Map()
   )
 
-  let claimItems = []
+  let claimedItems = []
 
   if (order.claims && order.claims.length) {
     for (const s of order.claims) {
-      claimItems = [...claimItems, ...s.claim_items]
+      claimedItems = [...claimedItems, ...s.claim_items]
 
       //
       //    Ticket is created to allow claims and swaps on claims and swaps without errors
@@ -48,7 +48,7 @@ export const filterItems = (order, isClaim) => {
     }
   }
 
-  for (const item of claimItems) {
+  for (const item of claimedItems) {
     let i = orderItems.get(item.item_id)
     if (i) {
       i.quantity = i.quantity - item.quantity

--- a/src/domain/orders/details/utils/create-filtering.js
+++ b/src/domain/orders/details/utils/create-filtering.js
@@ -1,0 +1,54 @@
+export const filterItems = (order, is_claim) => {
+  let tmpp = order.items.reduce(
+    (map, obj) => map.set(obj.id, { ...obj }),
+    new Map()
+  )
+
+  let claim_items = []
+
+  if (order.claims && order.claims.length) {
+    for (const s of order.claims) {
+      claim_items = [...claim_items, ...s.claim_items]
+
+      //
+      //    Ticket is created to allow claims and swaps on claims and swaps without errors
+      //
+      //   if (
+      //     s.fulfillment_status === "not_fulfilled" &&
+      //     s.payment_status === "na"
+      //   ) {
+      //     continue
+      //   }
+
+      //   if (s.additional_items && s.additional_items.length)
+      //     tmpp = s.additional_items
+      //       .filter(
+      //         it =>
+      //           it.shipped_quantity ||
+      //           it.shipped_quantity === it.fulfilled_quantity
+      //       )
+      //       .reduce((map, obj) => map.set(obj.id, { ...obj }), tmpp)
+    }
+  }
+
+  if (!is_claim) {
+    if (order.swaps && order.swaps.length) {
+      for (const s of order.swaps) {
+        tmpp = s.additional_items.reduce(
+          (map, obj) => map.set(obj.id, { ...obj }),
+          tmpp
+        )
+      }
+    }
+  }
+
+  for (const item of claim_items) {
+    let i = tmpp.get(item.item_id)
+    if (i) {
+      i.quantity = i.quantity - item.quantity
+      i.quantity !== 0 ? tmpp.set(i.id, i) : tmpp.delete(i.id)
+    }
+  }
+
+  return [...tmpp.values()]
+}


### PR DESCRIPTION
**What?**
- Improved consistency in the creation of claims, swaps and refund requests
- Ensured that the right quantity of an item can be refunded, swapped or claimed 
- Refactored filtering of quantities and items to ensure a uniform experience

**Why?**
- Previously the ordered quantities was shown after claims and swaps

**How?**
- Add all additional items and lineitems to a map
- iterate all claims, removing items that have been claimed

**Testing**
- Manual testing 