### PR TITLE
Fix: expandable sidebar issues

### DIFF
--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -89,6 +89,8 @@ const Sidebar = ({}) => {
       handleTriggerClick: () => setCurrentlyOpen(id),
     }
   }
+  // We store the `id` counter on the function object, as a state creates
+  // infinite updates, and we do not want the variable to be free floating.
   triggerHandler.id = 0
 
   return (

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -63,6 +63,7 @@ const Sidebar = ({}) => {
   const [storeName, setStoreName] = useState("")
   const [path, setPath] = useState("")
   const [orderOpen, setOrderOpen] = useState(false)
+  const [currentlyOpen, setCurrentlyOpen] = useState("")
 
   const fetchStore = async () => {
     const cache = localStorage.getItem("medusa::cache::store")
@@ -81,6 +82,15 @@ const Sidebar = ({}) => {
     fetchStore()
   }, [])
 
+  const triggerHandler = () => {
+    const id = triggerHandler.id++
+    return {
+      open: currentlyOpen === id,
+      handleTriggerClick: () => setCurrentlyOpen(id),
+    }
+  }
+  triggerHandler.id = 0
+
   return (
     <Container fontSize={1} fontFamily={"body"} pb={3} pt={4} px={4}>
       <Flex mx={-2} alignItems="center">
@@ -95,6 +105,7 @@ const Sidebar = ({}) => {
         <Collapsible
           transitionTime={150}
           transitionCloseTime={150}
+          {...triggerHandler()}
           trigger={
             <StyledItemContainer
               to="/a/orders"
@@ -145,6 +156,7 @@ const Sidebar = ({}) => {
         <Collapsible
           transitionTime={150}
           transitionCloseTime={150}
+          {...triggerHandler()}
           trigger={
             <StyledItemContainer
               to="/a/products"
@@ -170,46 +182,66 @@ const Sidebar = ({}) => {
             </Flex>
           </StyledItemContainer>
         </Collapsible>
-        <StyledItemContainer
-          to="/a/customers"
-          activeClassName="active"
-          partiallyActive
-        >
-          <img src="https://img.icons8.com/ios/50/000000/gender-neutral-user.png" />
-          <Text ml={2} variant="nav">
-            Customers
-          </Text>
-        </StyledItemContainer>
-        <StyledItemContainer
-          to="/a/discounts"
-          activeClassName="active"
-          partiallyActive
-        >
-          <img src="https://img.icons8.com/ios/50/000000/discount.png" />
-          <Text ml={2} variant="nav">
-            Discounts
-          </Text>
-        </StyledItemContainer>
-        <StyledItemContainer
-          to="/a/gift-cards"
-          activeClassName="active"
-          partiallyActive
-        >
-          <img src="https://img.icons8.com/ios/50/000000/gift-card.png" />
-          <Text ml={2} variant="nav">
-            Gift Cards
-          </Text>
-        </StyledItemContainer>
-        <StyledItemContainer
-          to="/a/settings"
-          activeClassName="active"
-          partiallyActive
-        >
-          <img src="https://img.icons8.com/ios/50/000000/settings--v1.png" />
-          <Text ml={2} variant="nav">
-            Settings
-          </Text>
-        </StyledItemContainer>
+        <Collapsible
+          {...triggerHandler()}
+          trigger={
+            <StyledItemContainer
+              to="/a/customers"
+              activeClassName="active"
+              partiallyActive
+            >
+              <img src="https://img.icons8.com/ios/50/000000/gender-neutral-user.png" />
+              <Text ml={2} variant="nav">
+                Customers
+              </Text>
+            </StyledItemContainer>
+          }
+        />
+        <Collapsible
+          {...triggerHandler()}
+          trigger={
+            <StyledItemContainer
+              to="/a/discounts"
+              activeClassName="active"
+              partiallyActive
+            >
+              <img src="https://img.icons8.com/ios/50/000000/discount.png" />
+              <Text ml={2} variant="nav">
+                Discounts
+              </Text>
+            </StyledItemContainer>
+          }
+        />
+        <Collapsible
+          {...triggerHandler()}
+          trigger={
+            <StyledItemContainer
+              to="/a/gift-cards"
+              activeClassName="active"
+              partiallyActive
+            >
+              <img src="https://img.icons8.com/ios/50/000000/gift-card.png" />
+              <Text ml={2} variant="nav">
+                Gift Cards
+              </Text>
+            </StyledItemContainer>
+          }
+        />
+        <Collapsible
+          {...triggerHandler()}
+          trigger={
+            <StyledItemContainer
+              to="/a/settings"
+              activeClassName="active"
+              partiallyActive
+            >
+              <img src="https://img.icons8.com/ios/50/000000/settings--v1.png" />
+              <Text ml={2} variant="nav">
+                Settings
+              </Text>
+            </StyledItemContainer>
+          }
+        />
       </Flex>
     </Container>
   )


### PR DESCRIPTION
### What
- Only allow one category to ever be expanded at once in the sidebar, and only collapse this when another element is expanded.

### Why
- To reduce clutter and ease of use

### How
- Implement custom trigger behaviour and apply this to all collapsables. (Cannot generate custom function component to increase reuse as this removes the animations) Also, this includes wrapping elements without subitems in a collapsible.