### PR TITLE
fix: dropdowns on top

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -14,7 +14,6 @@ export const DropdownContainer = styled(Box)`
 
   transform: ${props =>
     props.dropUp ? "translateY(-180px)" : "translateY(32px)"};
-  position: absolute;
   background-color: #fefefe;
   min-width: ${props => props.dropdownWidth};
   box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.1), 0 4px 11px hsla(0, 0%, 0%, 0.1);
@@ -25,7 +24,7 @@ export const DropdownContainer = styled(Box)`
 `
 
 const Scrollable = styled(Box)`
-  max-height: 80vh;
+  max-height: 200px;
   overflow: auto;
 `
 
@@ -37,7 +36,6 @@ const DropdownItem = styled.a`
   display: block;
   text-align: left;
   cursor: pointer;
-
   &:hover {
     background: #f1f3f5;
   }
@@ -50,7 +48,6 @@ const StyledInput = styled.input`
   font-size: 0.8em;
   padding: 5px 12px;
   color: #454545;
-
   outline: none;
 `
 
@@ -61,6 +58,7 @@ const Dropdown = ({
   onSearchChange,
   toggleText,
   leftAlign,
+  justifyContent,
   dropdownWidth,
   dropdownHeight,
   dropUp = false,
@@ -112,11 +110,16 @@ const Dropdown = ({
   const spacingProps = ["m", "mr", "ml", "mx"]
 
   return (
-    <Flex sx={{ position: "relative", width: showTrigger ? "auto" : "100%" }}>
+    <Flex
+      sx={{
+        width: showTrigger ? "auto" : "100%",
+        justifyContent: justifyContent ? justifyContent : "flex-end",
+      }}
+    >
       {showTrigger && (
         <Button
           sx={sx}
-          minHeight="25px"
+          minHeight="24px"
           alignItems="center"
           variant="primary"
           onClick={() => handleOpen()}
@@ -125,28 +128,30 @@ const Dropdown = ({
           {toggleText || <Ellipsis height="10px" />}
         </Button>
       )}
-      <DropdownContainer
-        dropUp={dropUp}
-        leftAlign={leftAlign}
-        minWidth={dropdownWidth || "160px"}
-        ref={ref}
-        isOpen={isOpen}
-        topPlacement={topPlacement}
-        {..._.pick(rest, spacingProps)}
-      >
-        {showSearch && (
-          <StyledInput
-            placeholder={searchPlaceholder}
-            value={search}
-            onChange={handleSearch}
-          />
-        )}
-        <Scrollable maxHeight={dropdownHeight || "80vh"}>
-          {React.Children.map(children, child => (
-            <DropdownItem>{child}</DropdownItem>
-          ))}
-        </Scrollable>
-      </DropdownContainer>
+      <Box mt={1} sx={{ zIndex: 1001, position: "absolute", width: "inherit" }}>
+        <DropdownContainer
+          dropUp={dropUp}
+          leftAlign={leftAlign}
+          minWidth={dropdownWidth || "160px"}
+          ref={ref}
+          isOpen={isOpen}
+          topPlacement={topPlacement}
+          {..._.pick(rest, spacingProps)}
+        >
+          {showSearch && (
+            <StyledInput
+              placeholder={searchPlaceholder}
+              value={search}
+              onChange={handleSearch}
+            />
+          )}
+          <Scrollable maxHeight={dropdownHeight || "200px"}>
+            {React.Children.map(children, child => (
+              <DropdownItem>{child}</DropdownItem>
+            ))}
+          </Scrollable>
+        </DropdownContainer>
+      </Box>
     </Flex>
   )
 }

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -15,7 +15,6 @@ const Modal = styled(Flex)`
   width: 100%;
   height: 100%;
   background-color: rgba(238, 240, 245, 0.7);
-  overflow: auto;
 `
 
 const ModalBody = styled(Flex)`

--- a/src/components/react-select/index.js
+++ b/src/components/react-select/index.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState, useRef } from "react"
 import styled from "@emotion/styled"
 import Select from "react-select"
 import AsyncCreatableSelect from "react-select/async-creatable"
@@ -122,6 +122,17 @@ export const ReactSelect = React.forwardRef(
     },
     ref
   ) => {
+    const selectRef = useRef(null)
+
+    const listener = () => {
+      const { select } = selectRef.current
+      if (select.props.menuIsOpen) select.blur()
+    }
+    useEffect(() => {
+      window.addEventListener("resize", listener)
+      return () => window.removeEventListener("resize", listener)
+    })
+
     return (
       <StyledSelect
         styles={{ ...selectStyles, ...customSelectStyles }}
@@ -129,6 +140,9 @@ export const ReactSelect = React.forwardRef(
         placeholder={placeholder}
         onChange={onChange}
         options={options}
+        menuPortalTarget={document.body}
+        menuPosition="fixed"
+        ref={selectRef}
         {...props}
       />
     )

--- a/src/domain/orders/details/claim/create.js
+++ b/src/domain/orders/details/claim/create.js
@@ -726,6 +726,7 @@ const ClaimMenu = ({ order, onCreate, onDismiss, toaster }) => {
                     leftAlign
                     toggleText={"+ Add product"}
                     showSearch
+                    justifyContent="flex-start"
                     onSearchChange={handleProductSearch}
                     searchPlaceholder={"Search by SKU, Name, etch."}
                   >

--- a/src/domain/orders/details/swap/create.js
+++ b/src/domain/orders/details/swap/create.js
@@ -398,6 +398,7 @@ const SwapMenu = ({ order, onCreate, onDismiss, toaster }) => {
               <Dropdown
                 leftAlign
                 toggleText={"+ Add product"}
+                justifyContent="flex-start"
                 showSearch
                 onSearchChange={handleProductSearch}
                 searchPlaceholder={"Search by SKU, Name, etch."}

--- a/src/domain/orders/new/components/items.js
+++ b/src/domain/orders/new/components/items.js
@@ -117,7 +117,7 @@ const Items = ({
         <Button
           variant="primary"
           onClick={() => setAddCustom(true)}
-          minHeight="33px"
+          minHeight="24px"
           mr={2}
         >
           + Add custom

--- a/src/domain/orders/new/index.js
+++ b/src/domain/orders/new/index.js
@@ -284,7 +284,7 @@ const NewOrder = ({}) => {
             >
               {searchResults.map(s => (
                 <Flex
-                  key={s.variant_id} 
+                  key={s.variant_id}
                   alignItems="center"
                   onClick={() => handleAddItemToSwap(s)}
                 >

--- a/src/domain/orders/new/new-order.js
+++ b/src/domain/orders/new/new-order.js
@@ -80,7 +80,6 @@ const NewOrder = ({ onDismiss, refresh }) => {
   const [showCustomPrice, setShowCustomPrice] = useState(false)
   const [creatingOrder, setCreatingOrder] = useState(false)
   const [noNotification, setNoNotification] = useState(false)
-  const [bodyElement, setBodyElement] = useState()
   const [searchingProducts, setSearchingProducts] = useState(false)
 
   const form = useForm({
@@ -331,10 +330,6 @@ const NewOrder = ({ onDismiss, refresh }) => {
   }
 
   useEffect(() => {
-    setBodyElement(document.body)
-  }, [])
-
-  useEffect(() => {
     if (regions) {
       form.setValue("region", regions[0])
     }
@@ -444,7 +439,6 @@ const NewOrder = ({ onDismiss, refresh }) => {
                 </Text>
               ) : (
                 <ReactSelect
-                  menuPortalTarget={bodyElement}
                   isClearable={false}
                   placeholder="Select shipping..."
                   onChange={so => handleOptionSelect(so)}


### PR DESCRIPTION
### What
- Changing dropdowns (`dropdown` and `react-select` components) are on top of modals (and other things). 

### Why
- These sometimes overflow the modal resulting in the user needing to scroll to select input. This is a nuisance for the user.

### How
- Wrap the `dropdown`'s `scrollable` so that itss absolute position is respected. Ensure that `menuPortalTarget` is always set to `document.body` for the `react-select` and that this is closed on resizing as to avoid random floating behaviour of the `scrollable`.