### PR TITLE
fix: Update default return value for fulfillment mapper

### DIFF
--- a/src/utils/fulfillment-providers.mapper.js
+++ b/src/utils/fulfillment-providers.mapper.js
@@ -16,6 +16,9 @@ export default function (provider) {
         value: "webshipper",
       }
     default:
-      return ""
+      return {
+        label: provider,
+        value: provider
+      }
   }
 }


### PR DESCRIPTION
### What

- If the fulfillment provider id is not known by the fulfillment mapper, it returns an empty string

### Why

- This is done as requested in https://github.com/medusajs/admin/issues/128

### How

- Just like pointed in the original Issue the provider value is returned for default case
 ```js
{
  label: provider,
  value: provider
}
```
