### PR TITLE
added quantity to calculate total price

### DIFF
--- a/src/domain/orders/new/new-order.js
+++ b/src/domain/orders/new/new-order.js
@@ -319,9 +319,9 @@ const NewOrder = ({ onDismiss, refresh }) => {
   const calculateTotal = () => {
     const tot = items.reduce((acc, next) => {
       if ("unit_price" in next) {
-        acc = acc + next.unit_price
+        acc = acc + next.unit_price * next.quantity
       } else {
-        acc = acc + extractUnitPrice(next, region, false)
+        acc = acc + extractUnitPrice(next, region, false) * next.quantity
       }
 
       return acc


### PR DESCRIPTION
### What
- Ensure that all `requirements` on a `shipping_option` respected when listing options for a given draft order.

### How
- Turns out we were missing to include quantity in our calculation of total price in the new draft order component.

### Testing
- Tested that requirements were adhered to when: (1) one `min_subtotal` requirement was present, (2) one `max_subtotal` requirement was present, (3) one of each were present, and (4) none were present.