### PR TITLE
fix: product details variants

### DIFF
--- a/src/components/variant-grid/index.js
+++ b/src/components/variant-grid/index.js
@@ -248,98 +248,98 @@ const VariantGrid = ({ product, variants, onChange, edit, onEdit, onCopy }) => {
           </tr>
         </TableHead>
         <tbody>
-          {variants.map(
-            (v, row) =>
-              (v.id !== undefined || !product) && (
-                <tr key={row}>
-                  {columns.map((c, col) => (
-                    <Td
-                      key={`${row}-${col}`}
-                      data-col={col}
-                      data-row={row}
-                      dragover={isDraggedOver({ col, row })}
-                      onDragEnter={handleDragEnter}
-                      onClick={() =>
-                        !c.readOnly &&
-                        setSelectedCell({
-                          field: c.field,
-                          value: v[c.field],
-                          row,
-                          col,
-                        })
-                      }
-                      selected={
-                        selectedCell.row === row && selectedCell.col === col
-                      }
-                      head={c.headCol}
-                    >
-                      {!(
-                        selectedCell.row === row && selectedCell.col === col
-                      ) && getDisplayValue(v, c, isDraggedOver({ col, row }))}
-                      {selectedCell.row === row && selectedCell.col === col && (
-                        <>
-                          <GridEditor
-                            ref={setRef}
-                            column={c}
-                            index={row}
-                            value={v[c.field]}
-                            onKeyDown={handleKey}
-                            onChange={handleChange}
-                          />
-                          <DragHandle draggable onDragEnd={handleDragEnd} />
-                        </>
-                      )}
-                    </Td>
-                  ))}
-                  {onEdit ? (
-                    <Box
-                      as="td"
-                      sx={{
-                        padding: "4px",
-                        borderBottom: "1px solid rgba(0,0,0,0.2)",
-                        backgroundColor: "white",
-                        textAlign: "right",
-                      }}
-                    >
-                      <Dropdown
-                        minHeight="24px"
-                        dropdownWidth="120px"
-                        width="28px"
-                        showTrigger={true}
-                        sx={{ padding: 0 }}
-                      >
-                        <Flex
-                          sx={{ padding: "8px 12px !important" }}
-                          alignItems="center"
-                          onClick={() => onEdit(row)}
-                        >
-                          <EditIcon />
-                          <Text ml={1} fontSize={14}>
-                            Edit
-                          </Text>
-                        </Flex>
-                        <Flex
-                          sx={{ padding: "8px 12px !important" }}
-                          alignItems="center"
-                          onClick={() => onCopy(row)}
-                        >
-                          <ClipboardIcon />
-                          <Text ml={1} fontSize={14}>
-                            Copy
-                          </Text>
-                        </Flex>
-                      </Dropdown>
-                    </Box>
-                  ) : (
-                    <Box
-                      as="td"
-                      height="24px"
-                      sx={{ borderBottom: "1px solid rgba(0,0,0,0.2)" }}
-                    />
+          {variants.map((v, row) => (
+            <tr key={row}>
+              {columns.map((c, col) => (
+                <Td
+                  key={`${row}-${col}`}
+                  data-col={col}
+                  data-row={row}
+                  dragover={isDraggedOver({ col, row })}
+                  onDragEnter={handleDragEnter}
+                  onClick={() =>
+                    !c.readOnly &&
+                    setSelectedCell({
+                      field: c.field,
+                      value: v[c.field],
+                      row,
+                      col,
+                    })
+                  }
+                  selected={
+                    selectedCell.row === row && selectedCell.col === col
+                  }
+                  head={c.headCol}
+                >
+                  {!(selectedCell.row === row && selectedCell.col === col) &&
+                    getDisplayValue(v, c, isDraggedOver({ col, row }))}
+                  {selectedCell.row === row && selectedCell.col === col && (
+                    <>
+                      <GridEditor
+                        ref={setRef}
+                        column={c}
+                        index={row}
+                        value={v[c.field]}
+                        onKeyDown={handleKey}
+                        onChange={handleChange}
+                      />
+                      <DragHandle draggable onDragEnd={handleDragEnd} />
+                    </>
                   )}
-                </tr>
-              )
-          )}
+                </Td>
+              ))}
+              {onEdit ? (
+                <Box
+                  as="td"
+                  sx={{
+                    padding: "4px",
+                    borderBottom: "1px solid rgba(0,0,0,0.2)",
+                    backgroundColor: "white",
+                    // position: "sticky !important",
+                    right: 0,
+                  }}
+                >
+                  <Dropdown
+                    minHeight="24px"
+                    dropdownWidth="120px"
+                    width="28px"
+                    sx={{
+                      height: 0,
+                      padding: 0,
+                      margin: "auto 0 auto auto",
+                    }}
+                  >
+                    <Flex
+                      sx={{ padding: "8px 12px !important" }}
+                      alignItems="center"
+                      onClick={() => onEdit(row)}
+                    >
+                      <EditIcon />
+                      <Text ml={1} fontSize={14}>
+                        Edit
+                      </Text>
+                    </Flex>
+                    <Flex
+                      sx={{ padding: "8px 12px !important" }}
+                      alignItems="center"
+                      onClick={() => onCopy(row)}
+                    >
+                      <ClipboardIcon />
+                      <Text ml={1} fontSize={14}>
+                        Copy
+                      </Text>
+                    </Flex>
+                  </Dropdown>
+                </Box>
+              ) : (
+                <Box
+                  as="td"
+                  height="24px"
+                  sx={{ borderBottom: "1px solid rgba(0,0,0,0.2)" }}
+                />
+              )}
+            </tr>
+          ))}
         </tbody>
       </StyledTable>
     </Wrapper>

--- a/src/components/variant-grid/index.js
+++ b/src/components/variant-grid/index.js
@@ -295,8 +295,7 @@ const VariantGrid = ({ product, variants, onChange, edit, onEdit, onCopy }) => {
                     padding: "4px",
                     borderBottom: "1px solid rgba(0,0,0,0.2)",
                     backgroundColor: "white",
-                    // position: "sticky !important",
-                    right: 0,
+                    textAlign: "right",
                   }}
                 >
                   <Dropdown
@@ -307,6 +306,7 @@ const VariantGrid = ({ product, variants, onChange, edit, onEdit, onCopy }) => {
                       height: 0,
                       padding: 0,
                       margin: "auto 0 auto auto",
+                      display: "inline-block",
                     }}
                   >
                     <Flex

--- a/src/components/variant-grid/index.js
+++ b/src/components/variant-grid/index.js
@@ -305,8 +305,6 @@ const VariantGrid = ({ product, variants, onChange, edit, onEdit, onCopy }) => {
                     sx={{
                       height: 0,
                       padding: 0,
-                      margin: "auto 0 auto auto",
-                      display: "inline-block",
                     }}
                   >
                     <Flex

--- a/src/domain/products/details/variants/variant-editor.js
+++ b/src/domain/products/details/variants/variant-editor.js
@@ -130,9 +130,9 @@ const VariantEditor = ({
     }))
 
     data.prices = data.prices.map(p => removeNullish(p))
-    const clean = convertEmptyStringToNull(data, numberFields)
+    const cleaned = convertEmptyStringToNull(data, numberFields)
 
-    onSubmit(clean)
+    onSubmit(cleaned)
   }
 
   return (

--- a/src/domain/products/details/variants/variant-editor.js
+++ b/src/domain/products/details/variants/variant-editor.js
@@ -376,7 +376,7 @@ const VariantEditor = ({
             Cancel
           </Button>
           <Button type="submit" variant="deep-blue">
-            {isCopy ? "Create" : "Save"}
+            {isCopy ? "Create" : "Edit"}
           </Button>
         </Modal.Footer>
       </Modal.Body>

--- a/src/domain/products/details/variants/variant-editor.js
+++ b/src/domain/products/details/variants/variant-editor.js
@@ -12,6 +12,9 @@ import Input from "../../../../components/input"
 import Modal from "../../../../components/modal"
 import Typography from "../../../../components/typography"
 import useMedusa from "../../../../hooks/use-medusa"
+import { convertEmptyStringToNull } from "../../../../utils/convert-empty-string-to-null"
+
+const numberFields = ["weight", "length", "width", "height"]
 
 const StyledLabel = styled(Label)`
   ${Typography.Base};
@@ -41,7 +44,7 @@ const VariantEditor = ({
   options,
   onSubmit,
   onDelete,
-  onClick,
+  onCancel,
   isCopy,
 }) => {
   const { store, isLoading } = useMedusa("store")
@@ -127,12 +130,13 @@ const VariantEditor = ({
     }))
 
     data.prices = data.prices.map(p => removeNullish(p))
-    const clean = removeNullish(data)
+    const clean = convertEmptyStringToNull(data, numberFields)
+
     onSubmit(clean)
   }
 
   return (
-    <Modal onClick={onClick}>
+    <Modal onClick={onCancel}>
       <Modal.Body as="form" onSubmit={handleSubmit(handleSave)}>
         <Modal.Header justifyContent="space-between" alignItems="center" px={4}>
           <Text fontSize="18px" fontWeight={700}>
@@ -140,7 +144,7 @@ const VariantEditor = ({
           </Text>
           <CloseIcon
             style={{ cursor: "pointer" }}
-            onClick={onClick}
+            onClick={onCancel}
             width={12}
             height={12}
           />
@@ -368,7 +372,7 @@ const VariantEditor = ({
           )}
         </Modal.Content>
         <Modal.Footer justifyContent="flex-end">
-          <Button mr={2} onClick={onClick} type="button" variant="primary">
+          <Button mr={2} onClick={onCancel} type="button" variant="primary">
             Cancel
           </Button>
           <Button type="submit" variant="deep-blue">


### PR DESCRIPTION
### What
- Fix: when trying to copy a variant, when cancel is clicked, a variant gets removed
- Slightly enhances the ux by reducing "save points": all changes occurring either in the grid or through the edit variant modal are only sent to our backend when the user clicks on the Save button
- Allow removal of weight, height, width, and length fields

### Why
- Better UX

###How
- Transform number fields from empty string to null before making a POST request
- Keep variants state in sync with the changes from the grid and the variant modals (copy + edit)