### PR TITLE
Fix: missing import navigate from gatsby

### DIFF
--- a/src/domain/orders/details/timeline/index.js
+++ b/src/domain/orders/details/timeline/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { navigate } from "gatsby"
 import { Text, Flex, Box, Image } from "rebass"
 import styled from "@emotion/styled"
 import moment from "moment"


### PR DESCRIPTION
What - Adds an import on src/domain/orders/details/timeline/index.js

Why - This prevents reference error while you click a product of the timeline.

Testing - The link no longer triggers the error and redirects to the correct page `/a/products/${productId}`

This solve the issue #198 