### PR TITLE
Fix: invalid login feedback

### DIFF
--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -28,11 +28,11 @@ const IndexPage = () => {
       .then(() => {
         navigate("/a")
       })
-      .finally(() => {
-        setLoading(false)
-      })
       .catch(e => {
         setIsInvalidLogin(true)
+      })
+      .finally(() => {
+        setLoading(false)
       })
   }
 

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -16,9 +16,10 @@ import MedusaClient from "../services/api"
 
 const IndexPage = () => {
   const [loading, setLoading] = useState(false)
-  const [errorLogin, setErrorLogin] = useState(false)
   const account = useContext(AccountContext)
   const { register, handleSubmit } = useForm()
+
+  const [isErrorLogin, setIsErrorLogin] = useState(false)
 
   const handleLogin = data => {
     setLoading(true)
@@ -31,7 +32,7 @@ const IndexPage = () => {
         setLoading(false)
       })
       .catch(e => {
-        setErrorLogin(true)
+        setIsErrorLogin(true)
       })
   }
 
@@ -71,7 +72,7 @@ const IndexPage = () => {
             <Text mb={4} fontWeight="bold" fontSize={4}>
               Sign in to your account
             </Text>
-            <Text color="red" display={errorLogin ? "inherit" : "none"}>
+            <Text color="red" display={isErrorLogin ? "inherit" : "none"}>
               Invalid email or password!
             </Text>
             {loading ? (

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -19,7 +19,7 @@ const IndexPage = () => {
   const account = useContext(AccountContext)
   const { register, handleSubmit } = useForm()
 
-  const [isErrorLogin, setIsErrorLogin] = useState(false)
+  const [isInvalidLogin, setIsInvalidLogin] = useState(false)
 
   const handleLogin = data => {
     setLoading(true)
@@ -32,7 +32,7 @@ const IndexPage = () => {
         setLoading(false)
       })
       .catch(e => {
-        setIsErrorLogin(true)
+        setIsInvalidLogin(true)
       })
   }
 
@@ -72,9 +72,9 @@ const IndexPage = () => {
             <Text mb={4} fontWeight="bold" fontSize={4}>
               Sign in to your account
             </Text>
-            <Text color="red" display={isErrorLogin ? "inherit" : "none"}>
-              Invalid email or password!
-            </Text>
+            {isInvalidLogin && (
+              <Text color="red">Invalid email or password!</Text>
+            )}
             {loading ? (
               <Flex justifyContent="center">
                 <Spinner dark width="20px" height="20px" />

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -16,6 +16,7 @@ import MedusaClient from "../services/api"
 
 const IndexPage = () => {
   const [loading, setLoading] = useState(false)
+  const [errorLogin, setErrorLogin] = useState(false)
   const account = useContext(AccountContext)
   const { register, handleSubmit } = useForm()
 
@@ -28,6 +29,9 @@ const IndexPage = () => {
       })
       .finally(() => {
         setLoading(false)
+      })
+      .catch(e => {
+        setErrorLogin(true)
       })
   }
 
@@ -66,6 +70,9 @@ const IndexPage = () => {
           <Box variant={"loginCard"} p={5} height="100%">
             <Text mb={4} fontWeight="bold" fontSize={4}>
               Sign in to your account
+            </Text>
+            <Text color="red" display={errorLogin ? "inherit" : "none"}>
+              Invalid email or password!
             </Text>
             {loading ? (
               <Flex justifyContent="center">


### PR DESCRIPTION
## What?
Shows a message to the user if the email or password is wrong. This solves the issue #181.
## Why?
In the current version, if the credentials are wrong it only shows the login again without any feedback.
## How?
I add a boolean flag on the page, but for further forms validations (issue #72) maybe is better to discuss a library to do this automatically like formik-yup.
## Testing?
I tested with invalid credentials, the only misbehave is that if the server is down and cant communicate it shows the same message.
## Screenshots
<img width="481" alt="Screen Shot 2021-12-17 at 12 08 51 PM" src="https://user-images.githubusercontent.com/33299343/146605568-64e79da4-2ec5-475f-a57b-635b636ee891.png">

