### PR TITLE
Fix: Add cancel save in timeline notes

### DIFF
--- a/src/domain/orders/details/index.js
+++ b/src/domain/orders/details/index.js
@@ -521,7 +521,7 @@ const OrderDetails = ({ id }) => {
       })
   }
 
-  const handleCreateNote = event => {
+  const handleEnterNote = event => {
     if (event.key === "Enter") {
       createNote()
     }
@@ -815,7 +815,7 @@ const OrderDetails = ({ id }) => {
               m={3}
               value={note}
               onChange={e => setNote(e.target.value)}
-              onKeyPress={handleCreateNote}
+              onKeyPress={handleEnterNote}
             />
             <Button
               mr={3}
@@ -829,7 +829,15 @@ const OrderDetails = ({ id }) => {
             >
               Cancel
             </Button>
-            <Button mt={3} variant="deep-blue" height="28px" width="100px">
+            <Button
+              mt={3}
+              variant="deep-blue"
+              height="28px"
+              width="100px"
+              onClick={() => {
+                createNote()
+              }}
+            >
               Save
             </Button>
           </Flex>

--- a/src/domain/orders/details/index.js
+++ b/src/domain/orders/details/index.js
@@ -817,6 +817,12 @@ const OrderDetails = ({ id }) => {
               onChange={e => setNote(e.target.value)}
               onKeyPress={handleCreateNote}
             />
+            <Button mr={3} mt={3} variant="primary" height="28px" width="100px">
+              Cancel
+            </Button>
+            <Button mt={3} variant="deep-blue" height="28px" width="100px">
+              Save
+            </Button>
           </Flex>
         )}
 

--- a/src/domain/orders/details/index.js
+++ b/src/domain/orders/details/index.js
@@ -817,7 +817,16 @@ const OrderDetails = ({ id }) => {
               onChange={e => setNote(e.target.value)}
               onKeyPress={handleCreateNote}
             />
-            <Button mr={3} mt={3} variant="primary" height="28px" width="100px">
+            <Button
+              mr={3}
+              mt={3}
+              variant="primary"
+              height="28px"
+              width="100px"
+              onClick={() => {
+                handleCancelNote()
+              }}
+            >
               Cancel
             </Button>
             <Button mt={3} variant="deep-blue" height="28px" width="100px">


### PR DESCRIPTION
## What?
Show controls for cancel/save notes in the timeline of the orders. This solves the issue #154.
## Why?
In the current version, is impossible to cancel the notes and the options are blocked until you write a note.
## How?
The two buttons were added, the function of `handleCancelNote` was already in the code but never implemented.
## Testing?
I tested canceling the note, adding the note with the save button, and pressing enter.
## Screenshots
<img width="1015" alt="Screen Shot 2021-12-17 at 4 45 08 PM" src="https://user-images.githubusercontent.com/33299343/146620059-c004b654-35ff-42ee-9655-60a651146a06.png">

