### PR TITLE
Feat/revamp modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/styled": "^10.0.27",
     "@material-ui/icons": "^4.11.2",
     "@popperjs/core": "^2.10.2",
+    "@radix-ui/react-dialog": "^0.1.5",
     "@rebass/forms": "^4.0.6",
     "@rebass/preset": "^4.0.5",
     "@storybook/theming": "^5.3.19",

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,37 +1,77 @@
+import styled from "@emotion/styled"
 import React from "react"
+import { Flex } from "rebass"
 
-const Modal = ({onClick, children, ...rest}) => {
-  return (
-    <div onClick={onClick} className="fixed top-0 left-0 z-[999] flex justify-center items-center w-full h-full overflow-auto bg-grey-90/40">
-      {children}
-    </div>
-  )
-}
+const Modal = styled(Flex)`
+  position: fixed;
+  z-index: 999;
+  top: 0;
+  left: 0;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 100%;
+  background-color: rgba(238, 240, 245, 0.7);
+  overflow: auto;
+`
+
+const ModalBody = styled(Flex)`
+  flex-direction: column;
+  max-height: 90vh;
+  min-width: 450px;
+  background-color: white;
+  border-radius: 5px;
+  box-shadow: 0px 3px 6px 0px rgba(0, 0, 0, 0.12),
+    0px 7px 15px 0px rgba(137, 149, 156, 0.12);
+`
+
+const ModalContent = styled(Flex)`
+  flex: 1;
+  overflow: auto;
+`
+
+const StyledHeader = styled(Flex)`
+  border-bottom: 1px solid #e3e8ee;
+`
+
+const StyledFooter = styled(Flex)`
+  align-items: center;
+  border-top: 1px solid #e3e8ee;
+`
 
 Modal.Body = ({ children, ...rest }) => {
   return (
-    <div onClick={e => e.stopPropagation()} className="flex flex-col bg-grey-0 min-w-modal rounded">
+    <ModalBody onClick={e => e.stopPropagation()} {...rest}>
       {children}
-    </div>
+    </ModalBody>
   )
 }
 
 Modal.Content = ({ children, ...rest }) => {
-  return (<div className="flex overflow-auto px-7 py-4">
-    {children}
-  </div>)
+  return (
+    <ModalContent p={3} {...rest}>
+      {children}
+    </ModalContent>
+  )
 }
 
-Modal.Header = ({ children, handleClose, ...rest }) => {
-  return (<div className="px-7 pt-3">
-    {children}
-  </div>)
+Modal.Header = ({ children, ...rest }) => {
+  return (
+    <StyledHeader p={3} onClick={e => e.stopPropagation()} {...rest}>
+      {children}
+    </StyledHeader>
+  )
 }
 
 Modal.Footer = ({ children, ...rest }) => {
-  return (<div onClick={e => e.stopPropagation()} className="items-center border-t border-grey-20 flex w-full px-7 pt-3.5 pb-5">
-    {children}
-  </div>)
+  return (
+    <StyledFooter p={3} onClick={e => e.stopPropagation()} {...rest}>
+      {children}
+    </StyledFooter>
+  )
 }
 
 export default Modal

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,77 +1,37 @@
-import styled from "@emotion/styled"
 import React from "react"
-import { Flex } from "rebass"
 
-const Modal = styled(Flex)`
-  position: fixed;
-  z-index: 1001;
-  top: 0;
-  left: 0;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: 100%;
-  height: 100%;
-  background-color: rgba(238, 240, 245, 0.7);
-  overflow: auto;
-`
-
-const ModalBody = styled(Flex)`
-  flex-direction: column;
-  max-height: 90vh;
-  min-width: 450px;
-  background-color: white;
-  border-radius: 5px;
-  box-shadow: 0px 3px 6px 0px rgba(0, 0, 0, 0.12),
-    0px 7px 15px 0px rgba(137, 149, 156, 0.12);
-`
-
-const ModalContent = styled(Flex)`
-  flex: 1;
-  overflow: auto;
-`
-
-const StyledHeader = styled(Flex)`
-  border-bottom: 1px solid #e3e8ee;
-`
-
-const StyledFooter = styled(Flex)`
-  align-items: center;
-  border-top: 1px solid #e3e8ee;
-`
+const Modal = ({onClick, children, ...rest}) => {
+  return (
+    <div onClick={onClick} className="fixed top-0 left-0 z-[999] flex justify-center items-center w-full h-full overflow-auto bg-grey-90/40">
+      {children}
+    </div>
+  )
+}
 
 Modal.Body = ({ children, ...rest }) => {
   return (
-    <ModalBody onClick={e => e.stopPropagation()} {...rest}>
+    <div onClick={e => e.stopPropagation()} className="flex flex-col bg-grey-0 min-w-modal rounded">
       {children}
-    </ModalBody>
+    </div>
   )
 }
 
 Modal.Content = ({ children, ...rest }) => {
-  return (
-    <ModalContent p={3} {...rest}>
-      {children}
-    </ModalContent>
-  )
+  return (<div className="flex overflow-auto px-7 py-4">
+    {children}
+  </div>)
 }
 
-Modal.Header = ({ children, ...rest }) => {
-  return (
-    <StyledHeader p={3} onClick={e => e.stopPropagation()} {...rest}>
-      {children}
-    </StyledHeader>
-  )
+Modal.Header = ({ children, handleClose, ...rest }) => {
+  return (<div className="px-7 pt-3">
+    {children}
+  </div>)
 }
 
 Modal.Footer = ({ children, ...rest }) => {
-  return (
-    <StyledFooter p={3} onClick={e => e.stopPropagation()} {...rest}>
-      {children}
-    </StyledFooter>
-  )
+  return (<div onClick={e => e.stopPropagation()} className="items-center border-t border-grey-20 flex w-full px-7 pt-3.5 pb-5">
+    {children}
+  </div>)
 }
 
 export default Modal

--- a/src/components/molecules/modal/index.js
+++ b/src/components/molecules/modal/index.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { ReactComponent as CloseIcon } from "../../../assets/svg/2.0/20px/x.svg"
+import * as Dialog from '@radix-ui/react-dialog'
+
+const Overlay = ({children, ...rest}) => {
+  return (<Dialog.Overlay className='fixed bg-grey-90/40 grid top-0 left-0 right-0 bottom-0 place-items-center overflow-y-auto'>
+    {children}
+  </Dialog.Overlay>)
+}
+
+const Content = ({children, ...rest}) => {
+  return (<Dialog.Content className='bg-grey-0 min-w-modal rounded'>
+    {children}
+  </Dialog.Content>)
+}
+
+const addProp = (children, prop) => {
+  return !Array.isArray(children) ? React.cloneElement(children, {...prop}) : 
+    children.map(child => React.cloneElement(child, {...prop}))
+}
+
+const Modal = ({children, onClick, isLargeModal, ...rest}) => {
+  const largeModal = isLargeModal
+  return (
+    <Dialog.Root open={true} onOpenChange={onClick}>
+      <Dialog.Portal>
+        <Overlay>
+          <Content>
+            {addProp(children, {largeModal})}
+          </Content> 
+        </Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>)
+}
+
+Modal.Body =  ({ children, largeModal = true, ...rest }) => {
+  return (
+    <div className='inter-base-regular' onClick={e => e.stopPropagation()}>
+      {addProp(children, {largeModal})}
+    </div>
+  )
+}
+
+Modal.Content = ({ children, largeModal = true, ...rest }) => {
+ return (<div className={`px-7 pt-5 ${largeModal ? "w-[750px] pb-7" : "pb-5"}`}> {addProp(children, {largeModal})}</div>)
+}
+
+Modal.Header = ({ children, largeModal = true, handleClose, showCloseIcon = true,...rest }) => {
+  return (
+    <div className='pl-7 pt-3.5 pr-3.5 flex flex-col w-full' onClick={e => e.stopPropagation()}>
+      <div className='pb-1 flex w-full justify-end'>
+        {showCloseIcon && (<span onClick={handleClose} className="stroke-grey-50 cursor-pointer">
+          <CloseIcon />
+        </span>)}
+      </div>
+      {addProp(children, {largeModal})}
+    </div>
+  )
+}
+
+Modal.Footer = ({ children, largeModal = true, ...rest }) => {
+  return (
+    <div onClick={e => e.stopPropagation()} className={`px-7  pb-5 flex w-full ${largeModal ? "border-t border-grey-20 pt-3.5": ""}`}>
+      {addProp(children, {largeModal})}
+    </div>
+  )
+}
+
+
+export default Modal

--- a/src/components/molecules/modal/index.js
+++ b/src/components/molecules/modal/index.js
@@ -1,28 +1,28 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { ReactComponent as CloseIcon } from "../../../assets/svg/2.0/20px/x.svg"
 import * as Dialog from '@radix-ui/react-dialog'
 
-const Overlay = ({children, ...rest}) => {
+const Overlay = ({children}) => {
   return (<Dialog.Overlay className='fixed bg-grey-90/40 grid top-0 left-0 right-0 bottom-0 place-items-center overflow-y-auto'>
     {children}
   </Dialog.Overlay>)
 }
 
-const Content = ({children, ...rest}) => {
+const Content = ({children}) => {
   return (<Dialog.Content className='bg-grey-0 min-w-modal rounded'>
     {children}
   </Dialog.Content>)
 }
 
 const addProp = (children, prop) => {
-  return !Array.isArray(children) ? React.cloneElement(children, prop) : 
-    children.map(child => React.cloneElement(child, prop))
+  return React.Children.map(children, c => React.cloneElement(c, prop))
 }
 
-const Modal = ({children, onClick, isLargeModal, ...rest}) => {
+const Modal = ({children, handleClose, isLargeModal = true}) => {
   const largeModal = isLargeModal
   return (
-    <Dialog.Root open={true} onOpenChange={onClick}>
+    <Dialog.Root open={true} onOpenChange={handleClose}>
       <Dialog.Portal>
         <Overlay>
           <Content>
@@ -33,7 +33,7 @@ const Modal = ({children, onClick, isLargeModal, ...rest}) => {
     </Dialog.Root>)
 }
 
-Modal.Body =  ({ children, largeModal = true, ...rest }) => {
+Modal.Body = ({ children, largeModal = true }) => {
   return (
     <div className='inter-base-regular' onClick={e => e.stopPropagation()}>
       {addProp(children, largeModal)}
@@ -41,30 +41,38 @@ Modal.Body =  ({ children, largeModal = true, ...rest }) => {
   )
 }
 
-Modal.Content = ({ children, largeModal = true, ...rest }) => {
- return (<div className={`px-7 pt-5 ${largeModal ? "w-[750px] pb-7" : "pb-5"}`}> {addProp(children, largeModal)}</div>)
+Modal.Content = ({ children, largeModal = true }) => {
+ return (<div className={`px-7 pt-5 ${largeModal ? "w-[750px] pb-7" : "pb-5"}`}> {children}</div>)
 }
 
-Modal.Header = ({ children, largeModal = true, handleClose, showCloseIcon = true,...rest }) => {
+Modal.Header = ({ children, handleClose = undefined }) => {
   return (
     <div className='pl-7 pt-3.5 pr-3.5 flex flex-col w-full' onClick={e => e.stopPropagation()}>
       <div className='pb-1 flex w-full justify-end'>
-        {showCloseIcon && (<span onClick={handleClose} className="stroke-grey-50 cursor-pointer">
+        {handleClose && (<span onClick={handleClose} className="stroke-grey-50 cursor-pointer">
           <CloseIcon />
         </span>)}
       </div>
-      {addProp(children, largeModal)}
+      {children}
     </div>
   )
 }
 
-Modal.Footer = ({ children, largeModal = true, ...rest }) => {
+Modal.Footer = ({ children, largeModal = true }) => {
   return (
     <div onClick={e => e.stopPropagation()} className={`px-7  pb-5 flex w-full ${largeModal ? "border-t border-grey-20 pt-3.5": ""}`}>
-      {addProp(children, largeModal)}
+      {children}
     </div>
   )
 }
 
+Modal.Header.propTypes = { 
+  handleClose: PropTypes.func, 
+}
+
+Modal.propTypes = {
+  isLargeModal: PropTypes.bool,
+  handleClose: PropTypes.func, 
+}
 
 export default Modal

--- a/src/components/molecules/modal/index.js
+++ b/src/components/molecules/modal/index.js
@@ -15,8 +15,8 @@ const Content = ({children, ...rest}) => {
 }
 
 const addProp = (children, prop) => {
-  return !Array.isArray(children) ? React.cloneElement(children, {...prop}) : 
-    children.map(child => React.cloneElement(child, {...prop}))
+  return !Array.isArray(children) ? React.cloneElement(children, prop) : 
+    children.map(child => React.cloneElement(child, prop))
 }
 
 const Modal = ({children, onClick, isLargeModal, ...rest}) => {
@@ -26,7 +26,7 @@ const Modal = ({children, onClick, isLargeModal, ...rest}) => {
       <Dialog.Portal>
         <Overlay>
           <Content>
-            {addProp(children, {largeModal})}
+            {addProp(children, largeModal)}
           </Content> 
         </Overlay>
       </Dialog.Portal>
@@ -36,13 +36,13 @@ const Modal = ({children, onClick, isLargeModal, ...rest}) => {
 Modal.Body =  ({ children, largeModal = true, ...rest }) => {
   return (
     <div className='inter-base-regular' onClick={e => e.stopPropagation()}>
-      {addProp(children, {largeModal})}
+      {addProp(children, largeModal)}
     </div>
   )
 }
 
 Modal.Content = ({ children, largeModal = true, ...rest }) => {
- return (<div className={`px-7 pt-5 ${largeModal ? "w-[750px] pb-7" : "pb-5"}`}> {addProp(children, {largeModal})}</div>)
+ return (<div className={`px-7 pt-5 ${largeModal ? "w-[750px] pb-7" : "pb-5"}`}> {addProp(children, largeModal)}</div>)
 }
 
 Modal.Header = ({ children, largeModal = true, handleClose, showCloseIcon = true,...rest }) => {
@@ -53,7 +53,7 @@ Modal.Header = ({ children, largeModal = true, handleClose, showCloseIcon = true
           <CloseIcon />
         </span>)}
       </div>
-      {addProp(children, {largeModal})}
+      {addProp(children, largeModal)}
     </div>
   )
 }
@@ -61,7 +61,7 @@ Modal.Header = ({ children, largeModal = true, handleClose, showCloseIcon = true
 Modal.Footer = ({ children, largeModal = true, ...rest }) => {
   return (
     <div onClick={e => e.stopPropagation()} className={`px-7  pb-5 flex w-full ${largeModal ? "border-t border-grey-20 pt-3.5": ""}`}>
-      {addProp(children, {largeModal})}
+      {addProp(children, largeModal)}
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,6 +1778,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
+  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.4":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
@@ -2512,6 +2519,158 @@
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
   integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+
+"@radix-ui/primitive@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-0.1.0.tgz#6206b97d379994f0d1929809db035733b337e543"
+  integrity sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-compose-refs@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz#cff6e780a0f73778b976acff2c2a5b6551caab95"
+  integrity sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-0.1.1.tgz#06996829ea124d9a1bc1dbe3e51f33588fab0875"
+  integrity sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dialog@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-0.1.5.tgz#4310659607f5ad0b8796623d5f7490dc47d3d295"
+  integrity sha512-WftvXcQSszUphCTLQkkpBIkrYYU0IYqgIvACLQady4BN4YHDgdNlrwdg2ti9QrXgq1PZ+0S/6BIaA1dmSuRQ2g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-dismissable-layer" "0.1.3"
+    "@radix-ui/react-focus-guards" "0.1.0"
+    "@radix-ui/react-focus-scope" "0.1.3"
+    "@radix-ui/react-id" "0.1.4"
+    "@radix-ui/react-portal" "0.1.3"
+    "@radix-ui/react-presence" "0.1.1"
+    "@radix-ui/react-primitive" "0.1.3"
+    "@radix-ui/react-slot" "0.1.2"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "^2.4.0"
+
+"@radix-ui/react-dismissable-layer@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.3.tgz#d427c7520c3799d2b957e40e7d67045d96120356"
+  integrity sha512-3veE7M8K13Qb+6+tC3DHWmWV9VMuuRoZvRLdrvz7biSraK/qkGBN4LbKZDaTdw2D2HS7RNpSd/sF8pFd3TaAgA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-primitive" "0.1.3"
+    "@radix-ui/react-use-body-pointer-events" "0.1.0"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
+    "@radix-ui/react-use-escape-keydown" "0.1.0"
+
+"@radix-ui/react-focus-guards@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz#ba3b6f902cba7826569f8edc21ff8223dece7def"
+  integrity sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.3.tgz#b1cc825b6190001d731417ed90d192d13b41bce1"
+  integrity sha512-bKi+lw14SriQqYWMBe13b/wvxSqYMC+3FylMUEwOKA6JrBoldpkhX5XffGDdpDRTTpjbncdH3H7d1PL5Bs7Ikg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-primitive" "0.1.3"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
+
+"@radix-ui/react-id@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-0.1.4.tgz#4cd6126e6ac8a43ebe6d52948a068b797cc9ad71"
+  integrity sha512-/hq5m/D0ZfJWOS7TLF+G0l08KDRs87LBE46JkAvgKkg1fW4jkucx9At9D9vauIPSbdNmww5kXEp566hMlA8eXA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
+
+"@radix-ui/react-portal@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-0.1.3.tgz#56826e789b3d4e37983f6d23666e3f1b1b9ee358"
+  integrity sha512-DrV+sPYLs0HhmX5/b7yRT6nLM9Nl6FtQe2KUG+46kiCOKQ+0XzNMO5hmeQtyq0mRf/qlC02rFu6OMsWpIqVsJg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "0.1.3"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
+
+"@radix-ui/react-presence@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.1.1.tgz#2088dec6f4f8042f83dd2d6bf9e8ef09dadbbc15"
+  integrity sha512-LsL+NcWDpFUAYCmXeH02o4pgqcSLpwxP84UIjCtpIKrsPe2vLuhcp79KC/jZJeXz+of2lUpMAxpM+eCpxFZtlg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
+
+"@radix-ui/react-primitive@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.1.3.tgz#585c35ef2ec06bab0ea9e0fc5c916e556661b881"
+  integrity sha512-fcyADaaAx2jdqEDLsTs6aX50S3L1c9K9CC6XMpJpuXFJCU4n9PGTFDZRtY2gAoXXoRCPIBsklCopSmGb6SsDjQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "0.1.2"
+
+"@radix-ui/react-slot@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-0.1.2.tgz#e6f7ad9caa8ce81cc8d532c854c56f9b8b6307c8"
+  integrity sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "0.1.0"
+
+"@radix-ui/react-use-body-pointer-events@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.0.tgz#29b211464493f8ca5149ce34b96b95abbc97d741"
+  integrity sha512-svPyoHCcwOq/vpWNEvdH/yD91vN9p8BtiozNQbjVmJRxQ/vS12zqk70AxTGWe+2ZKHq2sggpEQNTv1JHyVFlnQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
+
+"@radix-ui/react-use-callback-ref@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz#934b6e123330f5b3a6b116460e6662cbc663493f"
+  integrity sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz#4fced164acfc69a4e34fb9d193afdab973a55de1"
+  integrity sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
+
+"@radix-ui/react-use-escape-keydown@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz#dc80cb3753e9d1bd992adbad9a149fb6ea941874"
+  integrity sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
+
+"@radix-ui/react-use-layout-effect@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz#ebf71bd6d2825de8f1fbb984abf2293823f0f223"
+  integrity sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@reach/alert@0.10.3":
   version "0.10.3"
@@ -4144,6 +4303,13 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-hidden@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
+  integrity sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==
+  dependencies:
+    tslib "^1.0.0"
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -14466,6 +14632,17 @@ react-remove-scroll@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.3.0.tgz"
   integrity sha512-UqVimLeAe+5EHXKfsca081hAkzg3WuDmoT9cayjBegd6UZVhlTEchleNp9J4TMGkb/ftLve7ARB5Wph+HJ7A5g==
+  dependencies:
+    react-remove-scroll-bar "^2.1.0"
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+    use-callback-ref "^1.2.3"
+    use-sidecar "^1.0.1"
+
+react-remove-scroll@^2.4.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz#83d19b02503b04bd8141ed6e0b9e6691a2e935a6"
+  integrity sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==
   dependencies:
     react-remove-scroll-bar "^2.1.0"
     react-style-singleton "^2.1.0"


### PR DESCRIPTION
**What**
- create new molecule `Modal` using radix-ui 
- Allow switching between large and small modals with a boolean

**How**
- adapt the `Dialog` component from radix-ui
- clone child elements as the modal is created, setting the `isLargeModal` prop of each child 
  - *I would like some feedback on the design choice here* 

**Adding props through the DOM tree**
When creating this component i thought it would be nice to be able to define if a modal was large or small with a single boolean value. Since different parts of the modal depends on this, specifically the padding and border of the footer, I looked at how to pass props to the `{children}` element at runtime. 
I found two different options for how to achieve this:

  1. Clone the child elements and pass `isLargeModal` as a prop throughout the DOM tree
  2. Create a local context which would be replicated for each modal

I chose option nr. 1 since it seemed the least over-engineered and from what I could read using `React.cloneElement` does not mean taking a performance hit in terms of the render, especially when working with such small components as modals. Using contexts is something we can always do instead at a later time because of the relative small size of the component, though the usecase seems to be for bigger elements of an application rather than an invite modal.

I have implemented this practically as a helper method in the `index.js` file of the modal molecule. The helper method uses the `React.cloneElement` method to add the prop to either a single element or array of elements: 
```javascript
const addProp = (children, prop) => {
  return !Array.isArray(children) ? React.cloneElement(children, prop) : 
    children.map(child => React.cloneElement(child, prop))
}
```

This method is then used in each of the Modal components and subcomponents to add the `isLargeModal` prop to each of the children as such: 

```javascript
const Modal = ({children, onClick, isLargeModal, ...rest}) => {
  const largeModal = isLargeModal
  return (
    <Dialog.Root open={true} onOpenChange={onClick}>
      <Dialog.Portal>
        <Overlay>
          <Content>
            {addProp(children, largeModal)}
          </Content> 
        </Overlay>
      </Dialog.Portal>
    </Dialog.Root>)
}
```

**Example**
Below is an example of how to use the modal, each part of the modal is optional, and the top-level `Modal` component has a prop `isLargeModal` to indicate if the modal has width 750 or if it's smaller. 

furthermore when `isLargeModal` is set it will make the footer wider and add a hairline border top to the footer.

```javascript
return (
    <Modal isLargeModal={true} onClick={handleClose}>
      <Modal.Body >
        <Modal.Header handleClose={handleClose} justifyContent="space-between" alignItems="center">
          <span className="text-large font-semibold">Invite Users</span>
        </Modal.Header>
        <Modal.Content flexDirection="column">
            <InputField
              placeholder="lebron@james.com"
              value={email}
              onChange={e => setEmail(e.target.value)}
            />
        </Modal.Content>
        <Modal.Footer>
          <div className="flex w-full justify-end">
            <Button mr={2} variant="primary" onClick={handleClose}>
              Cancel
            </Button>
            <Button loading={isLoading} onClick={handleSubmit} variant="cta">
              Invite
            </Button>
          </div>
        </Modal.Footer>
      </Modal.Body>
    </Modal>
  )
```