### PR TITLE
Hide canceled swaps from payment sum

### DIFF
--- a/src/domain/orders/details/index.js
+++ b/src/domain/orders/details/index.js
@@ -293,7 +293,9 @@ const PaymentDetails = ({ order }) => {
   }
 
   if (order?.swaps?.length) {
-    swapAmount = _.sum(order.swaps.map(el => el.difference_due))
+    swapAmount = _.sum(order.swaps
+                    .filter(el => el.canceled_at === null)
+                    .map(el => el.difference_due))
   }
 
   return (


### PR DESCRIPTION
Hi, this is my solution for the issue #195 

In the past, when we consulted the details of an order
<img width="1416" alt="Screen Shot 2021-12-30 at 9 30 48" src="https://user-images.githubusercontent.com/35499170/147760964-00a3f009-5cdb-4b53-b56b-503ccf2c2692.png">

When we checked the payment overview
<img width="804" alt="Screen Shot 2021-12-30 at 9 31 54" src="https://user-images.githubusercontent.com/35499170/147761031-a37ee39e-899a-4456-a80e-0649ea2e7397.png">

In the sum, those swaps that were canceled were considered. This should not be like that. My solution was to add a filter to exclude those swaps canceled when we make the map for the sum.

Please let me know if there is anything I can improve :)
