### PR TITLE
Fix/swaps undefined and border needs to be boolean

### DIFF
--- a/src/components/layout/popover.js
+++ b/src/components/layout/popover.js
@@ -70,7 +70,7 @@ const Popover = ({ children, id }) => {
 
   return (
     <Tooltip
-      border="true"
+      border={true}
       ref={ref}
       textColor="black"
       backgroundColor="white"

--- a/src/domain/orders/swaps/index.js
+++ b/src/domain/orders/swaps/index.js
@@ -135,7 +135,7 @@ const SwapIndex = ({}) => {
             <Spinner dark />
           </Box>
         </Flex>
-      ) : swaps === undefined ? (
+      ) : !swaps?.length ? (
         <Flex alignItems="center" justifyContent="center" mt="10%">
           <Text height="75px" fontSize="16px">
             No swaps found

--- a/src/domain/orders/swaps/index.js
+++ b/src/domain/orders/swaps/index.js
@@ -135,7 +135,7 @@ const SwapIndex = ({}) => {
             <Spinner dark />
           </Box>
         </Flex>
-      ) : !swaps.length ? (
+      ) : swaps === undefined ? (
         <Flex alignItems="center" justifyContent="center" mt="10%">
           <Text height="75px" fontSize="16px">
             No swaps found


### PR DESCRIPTION
Solves [#211 ](https://github.com/medusajs/admin/issues/211)

**What's the problem**
The application was breaking at the moment to go to the swaps page because the `swap` variable was undefined:
<img width="1438" alt="Screen Shot 2021-12-30 at 11 29 20" src="https://user-images.githubusercontent.com/78670199/147785687-88c02c4c-e0cf-4ffa-9466-21f2ba32986f.png">

Also, we were having a console error in the `border` variable in the components/popover. It wasn't breaking the application but it could be fixed too.

<img width="1438" alt="Screen Shot 2021-12-30 at 11 46 09" src="https://user-images.githubusercontent.com/78670199/147785770-44f328f1-30e5-4d98-937f-96f1d145c74b.png">

**Why we should fix it**
We should fix it because the application should work as normal even if there's no data. We need to add a validation if there's no data because at the moment of use `!swaps.length if swaps is undefined it is going to break.

**How I fixed it**
Just changed the validation from `!swaps.length ?` to `swaps === undefined ?` in the swaps/index.js
And just changed `border="true"` to `border={true}` in the components/layout/popover.js
And it's working fine:
<img width="1438" alt="Screen Shot 2021-12-30 at 13 03 47" src="https://user-images.githubusercontent.com/78670199/147785972-0e6f3150-f98a-4dd8-a522-7b7e54e0a1d5.png">

**Testing**
No needed.

Hope it is useful, I was navigating through the application and saw that. Tell me anything, thanks!