### PR TITLE
Feat: Revamp delete prompt

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -236,6 +236,10 @@
     @apply bg-grey-0 text-grey-90 border border-grey-20 hover:bg-grey-5 active:bg-grey-5 active:text-violet-60  focus:border-violet-60 disabled:bg-grey-0 disabled:text-grey-30;
   }
 
+  .btn-danger {
+    @apply bg-rose-50 text-grey-0 hover:bg-rose-40 active:bg-rose-60 disabled:bg-grey-20 disabled:text-grey-40;
+  }
+
   .btn-ghost {
     @apply bg-transparent text-grey-90 hover:bg-grey-5 active:bg-grey-5 active:text-violet-60  focus:border-violet-60 disabled:bg-transparent disabled:text-grey-30;
   }

--- a/src/components/fundamentals/button/index.tsx
+++ b/src/components/fundamentals/button/index.tsx
@@ -3,7 +3,7 @@ import React, { Children } from "react"
 import Spinner from "../../atoms/spinner"
 
 type ButtonProps = {
-  variant: "primary" | "secondary" | "ghost"
+  variant: "primary" | "secondary" | "ghost" | "danger"
   size: "small" | "medium" | "large"
   loading?: boolean
 } & React.ButtonHTMLAttributes<HTMLButtonElement>
@@ -29,6 +29,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       ["btn-primary"]: variant === "primary",
       ["btn-secondary"]: variant === "secondary",
       ["btn-ghost"]: variant === "ghost",
+      ["btn-danger"]: variant === "danger",
     })
 
     const sizeClassname = clsx({

--- a/src/components/molecules/modal/index.tsx
+++ b/src/components/molecules/modal/index.tsx
@@ -9,7 +9,7 @@ type ModalProps = {
 }
 
 type ModalChildProps = {
-  largeModal?: boolean
+  isLargeModal?: boolean
 }
 
 type ModalHeaderProps = {
@@ -40,36 +40,35 @@ const Content: React.FC = ({ children }) => {
 }
 
 const addProp = (children, prop) => {
-  return React.Children.map(children, c => React.cloneElement(c, prop))
+  return React.Children.map(children, child => React.cloneElement(child, prop))
 }
 
 const Modal: ModalType = ({ handleClose, isLargeModal = true, children }) => {
-  const largeModal = isLargeModal
   return (
     <Dialog.Root open={true} onOpenChange={handleClose}>
       <Dialog.Portal>
         <Overlay>
-          <Content>{addProp(children, largeModal)}</Content>
+          <Content>{addProp(children, { isLargeModal })}</Content>
         </Overlay>
       </Dialog.Portal>
     </Dialog.Root>
   )
 }
 
-Modal.Body = ({ children, largeModal }) => {
+Modal.Body = ({ children, isLargeModal }) => {
   return (
     <div className="inter-base-regular" onClick={e => e.stopPropagation()}>
-      {addProp(children, largeModal)}
+      {addProp(children, { isLargeModal })}
     </div>
   )
 }
 
-Modal.Content = ({ children, largeModal = true }) => {
+Modal.Content = ({ children, isLargeModal }) => {
   return (
     <div
       className={clsx("px-7 pt-5", {
-        ["w-largeModal pb-7"]: largeModal,
-        ["pb-5"]: !largeModal,
+        ["w-largeModal pb-7"]: isLargeModal,
+        ["pb-5"]: !isLargeModal,
       })}
     >
       {children}
@@ -95,12 +94,12 @@ Modal.Header = ({ handleClose = undefined, children }) => {
   )
 }
 
-Modal.Footer = ({ children, largeModal = true }) => {
+Modal.Footer = ({ children, isLargeModal }) => {
   return (
     <div
       onClick={e => e.stopPropagation()}
       className={clsx("px-7  pb-5 flex w-full", {
-        "border-t border-grey-20 pt-4": largeModal,
+        "border-t border-grey-20 pt-4": isLargeModal,
       })}
     >
       {children}

--- a/src/components/organisms/delete-prompt.tsx
+++ b/src/components/organisms/delete-prompt.tsx
@@ -5,17 +5,21 @@ import useMedusa from "../../hooks/use-medusa"
 import { getErrorMessage } from "../../utils/error-messages"
 
 type DeletePromptProps = {
-  heading: string
-  text: string
+  heading?: string
+  text?: string
   successText?: string
+  cancelText?: string
+  confirmText?: string
   handleClose: () => void
   onDelete: () => Promise<void>
 }
 
 const DeletePrompt: React.FC<DeletePromptProps> = ({
-  heading,
-  text,
-  successText,
+  heading = "Are you sure?",
+  text = "Are you sure you want to delete?",
+  successText = "Delete successful",
+  cancelText = "No, cancel",
+  confirmText = "Yes, remove",
   handleClose,
   onDelete,
 }) => {
@@ -27,7 +31,7 @@ const DeletePrompt: React.FC<DeletePromptProps> = ({
 
     setIsLoading(true)
     onDelete()
-      .then(() => toaster(successText || "Delete successful", "success"))
+      .then(() => toaster(successText, "success"))
       .catch(err => toaster(getErrorMessage(err), "error"))
       .finally(() => {
         setIsLoading(false)
@@ -40,12 +44,8 @@ const DeletePrompt: React.FC<DeletePromptProps> = ({
       <Modal.Body>
         <Modal.Content>
           <div className="flex flex-col">
-            <span className="inter-large-semibold">
-              {heading || "Are you sure?"}
-            </span>
-            <span className="inter-base-regular mt-1 text-grey-50">
-              {text || "Are you sure you want to delete?"}
-            </span>
+            <span className="inter-large-semibold">{heading}</span>
+            <span className="inter-base-regular mt-1 text-grey-50">{text}</span>
           </div>
         </Modal.Content>
         <Modal.Footer>
@@ -56,7 +56,7 @@ const DeletePrompt: React.FC<DeletePromptProps> = ({
               size="small"
               onClick={handleClose}
             >
-              No, cancel
+              {cancelText}
             </Button>
             <Button
               loading={isLoading}
@@ -65,7 +65,7 @@ const DeletePrompt: React.FC<DeletePromptProps> = ({
               variant="danger"
               onClick={handleSubmit}
             >
-              Yes, remove
+              {confirmText}
             </Button>
           </div>
         </Modal.Footer>

--- a/src/components/organisms/delete-prompt.tsx
+++ b/src/components/organisms/delete-prompt.tsx
@@ -52,7 +52,7 @@ const DeletePrompt: React.FC<DeletePromptProps> = ({
           <div className="flex w-full h-8 justify-end">
             <Button
               variant="ghost"
-              className="mr-2 w-32 text-small justify-center"
+              className="mr-2 w-24 text-small justify-center"
               size="small"
               onClick={handleClose}
             >
@@ -61,7 +61,7 @@ const DeletePrompt: React.FC<DeletePromptProps> = ({
             <Button
               loading={isLoading}
               size="small"
-              className="w-32 text-small justify-center"
+              className="w-24 text-small justify-center"
               variant="danger"
               onClick={handleSubmit}
             >

--- a/src/components/organisms/delete-prompt.tsx
+++ b/src/components/organisms/delete-prompt.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react"
+import Modal from "../molecules/modal"
+import Button from "../fundamentals/button"
+import useMedusa from "../../hooks/use-medusa"
+import { getErrorMessage } from "../../utils/error-messages"
+import { AxiosPromise } from "axios"
+
+type DeletePromptProps = {
+  heading: string
+  text: string
+  successText?: string
+  handleClose: () => void
+  onDelete: () => Promise<void>
+}
+
+const DeletePrompt: React.FC<DeletePromptProps> = ({
+  heading,
+  text,
+  successText,
+  handleClose,
+  onDelete,
+}) => {
+  const { toaster } = useMedusa("store")
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = e => {
+    e.preventDefault()
+
+    setIsLoading(true)
+    onDelete()
+      .then(() => toaster(successText || "Delete successful", "success"))
+      .catch(err => toaster(getErrorMessage(err), "error"))
+      .finally(() => {
+        setIsLoading(false)
+        handleClose()
+      })
+  }
+
+  return (
+    <Modal handleClose={handleClose}>
+      <Modal.Body>
+        <Modal.Content>
+          <div className="flex flex-col">
+            <span className="inter-large-semibold">
+              {heading || "Are you sure?"}
+            </span>
+            <span className="inter-base-regular mt-1 text-grey-50">
+              {text || "Are you sure you want to delete?"}
+            </span>
+          </div>
+        </Modal.Content>
+        <Modal.Footer>
+          <div className="flex w-full h-8 justify-end">
+            <Button
+              variant="ghost"
+              className="mr-2 w-32 text-small justify-center"
+              size="small"
+              onClick={handleClose}
+            >
+              No, cancel
+            </Button>
+            <Button
+              loading={isLoading}
+              size="small"
+              className="w-32 text-small justify-center"
+              variant="danger"
+              onClick={handleSubmit}
+            >
+              Yes, remove
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal.Body>
+    </Modal>
+  )
+}
+
+export default DeletePrompt

--- a/src/components/organisms/delete-prompt.tsx
+++ b/src/components/organisms/delete-prompt.tsx
@@ -3,7 +3,6 @@ import Modal from "../molecules/modal"
 import Button from "../fundamentals/button"
 import useMedusa from "../../hooks/use-medusa"
 import { getErrorMessage } from "../../utils/error-messages"
-import { AxiosPromise } from "axios"
 
 type DeletePromptProps = {
   heading: string


### PR DESCRIPTION
**What**
- add a danger button to button component and `global.css`
- fix modal widths
- Add delete prompt 

Delete promp has the following properties: 
- `heading: string`: heading for the prompt ie. 'Remove user'
- `text: string`: text for prompt body ie. 'Are you sure you want to remove this user?'
- `successText?: string`: success text for toaster
- `handleClose: () => void`: close function for modal
- `onDelete: () => Promise<void>`: function which deletes the entity in question

![image](https://user-images.githubusercontent.com/88927411/148911072-9a51318b-1701-4441-9773-1f054857685f.png)
