### PR TITLE
fix: two split pane + layout

### DIFF
--- a/src/components/organisms/body-card.tsx
+++ b/src/components/organisms/body-card.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx"
 import React from "react"
 import { useScroll } from "../../hooks/use-scroll"
 import Button from "../fundamentals/button"
@@ -11,18 +12,26 @@ type BodyCardProps = {
     onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
   }[]
   actionables?: ActionType[]
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 const BodyCard: React.FC<BodyCardProps> = ({
   title,
   subtitle,
   events,
   actionables,
+  className,
   children,
+  ...rest
 }) => {
   const { isScrolled, scrollListener } = useScroll({ threshold: 16 })
   return (
-    <div className="rounded-rounded border bg-grey-0 border-grey-20 h-full overflow-hidden flex flex-col min-h-[350px] w-full relative">
+    <div
+      className={clsx(
+        "rounded-rounded border bg-grey-0 border-grey-20 h-full overflow-hidden flex flex-col min-h-[350px] w-full relative",
+        className
+      )}
+      {...rest}
+    >
       {isScrolled && (
         <div className="absolute top-0 left-0 right-0 bg-gradient-to-b from-grey-0 to-transparent h-xlarge z-10" />
       )}

--- a/src/components/templates/layout.tsx
+++ b/src/components/templates/layout.tsx
@@ -8,8 +8,8 @@ const Layout: React.FC = ({ children }) => {
       <Sidebar />
       <div className="flex flex-col flex-1">
         <Topbar />
-        <div className="large:px-xlarge py-xlarge bg-grey-5 min-h-content overflow-y-scroll">
-          <main className="xsmall:mx-base small:mx-xlarge medium:mx-4xlarge large:mx-auto large:max-w-7xl large:w-full h-full">
+        <div className="large:px-xlarge py-xlarge bg-grey-5 min-h-content overflow-y-auto">
+          <main className="xsmall:mx-base small:mx-xlarge medium:mx-4xlarge large:mx-auto large:max-w-7xl large:w-full">
             {children}
           </main>
         </div>

--- a/src/components/templates/layout.tsx
+++ b/src/components/templates/layout.tsx
@@ -9,7 +9,7 @@ const Layout: React.FC = ({ children }) => {
       <div className="flex flex-col flex-1">
         <Topbar />
         <div className="large:px-xlarge py-xlarge bg-grey-5 min-h-content overflow-y-auto">
-          <main className="xsmall:mx-base small:mx-xlarge medium:mx-4xlarge large:mx-auto large:max-w-7xl large:w-full">
+          <main className="xsmall:mx-base small:mx-xlarge medium:mx-4xlarge large:mx-auto large:max-w-7xl large:w-full h-full">
             {children}
           </main>
         </div>

--- a/src/components/templates/two-split-pane.tsx
+++ b/src/components/templates/two-split-pane.tsx
@@ -1,14 +1,26 @@
 import React, { Children } from "react"
+import { useComputedHeight } from "../../hooks/use-computed-height"
 
 const TwoSplitPane: React.FC = ({ children }) => {
   const childrenCount = Children.count(children)
+  const { ref, height } = useComputedHeight(32)
+
+  const heightClass = height
+    ? {
+        gridTemplateRows: `${height}px`,
+      }
+    : null
 
   if (childrenCount > 2) {
     throw new Error("TwoSplitPane can only have two or less children")
   }
 
   return (
-    <div className="grid gap-large grid-cols-1 medium:grid-cols-2">
+    <div
+      className="grid gap-large grid-cols-1 medium:grid-cols-2"
+      style={heightClass}
+      ref={ref}
+    >
       {Children.map(children, (child, i) => {
         return (
           <div className="w-full h-full" key={i}>

--- a/src/components/templates/two-split-pane.tsx
+++ b/src/components/templates/two-split-pane.tsx
@@ -8,10 +8,10 @@ const TwoSplitPane: React.FC = ({ children }) => {
   }
 
   return (
-    <div className="flex flex-col gap-large items-baseline h-full medium:flex-row">
+    <div className="grid gap-large grid-cols-1 medium:grid-cols-2">
       {Children.map(children, (child, i) => {
         return (
-          <div className="w-full medium:w-1/2 h-full" key={i}>
+          <div className="w-full h-full" key={i}>
             {child}
           </div>
         )

--- a/src/domain/settings/personal-information.tsx
+++ b/src/domain/settings/personal-information.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useContext, useState } from "react"
+import clsx from "clsx"
+import { navigate } from "gatsby"
+import React, { useContext, useState } from "react"
 import { useForm } from "react-hook-form"
-import TwoSplitPane from "../../components/templates/two-split-pane"
-import BodyCard from "../../components/organisms/body-card"
-import BreadCrumb from "../../components/molecules/breadcrumb"
+import Avatar from "../../components/atoms/avatar"
 import Spinner from "../../components/atoms/spinner"
+import BreadCrumb from "../../components/molecules/breadcrumb"
+import Input from "../../components/molecules/input"
+import BodyCard from "../../components/organisms/body-card"
+import FileUploadModal from "../../components/organisms/file-upload-modal"
+import TwoSplitPane from "../../components/templates/two-split-pane"
 import { AccountContext } from "../../context/account"
 import useMedusa from "../../hooks/use-medusa"
-import { navigate } from "gatsby"
 import { getErrorMessage } from "../../utils/error-messages"
-import Input from "../../components/molecules/input"
-import FileUploadModal from "../../components/organisms/file-upload-modal"
-import clsx from "clsx"
-import Avatar from "../../components/atoms/avatar"
 
 const PersonalInformation = () => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
@@ -66,6 +66,7 @@ const PersonalInformation = () => {
           title="Personal information"
           subtitle="Manage your Medusa profile"
           events={events}
+          className={"h-auto max-h-full"}
         >
           <div>
             <span className="inter-base-semibold">Picture</span>
@@ -91,7 +92,6 @@ const PersonalInformation = () => {
               </div>
             </div>
           </div>
-
           <div className="mt-6">
             <span className="inter-base-semibold">General</span>
             <div className="flex mt-4">

--- a/src/hooks/use-computed-height.ts
+++ b/src/hooks/use-computed-height.ts
@@ -1,17 +1,19 @@
 import { useLayoutEffect, useRef } from "react"
+import { useWindowDimensions } from "./use-window-dimensions"
 
 export const useComputedHeight = (bottomPad: number) => {
   const ref = useRef(null)
   const heightRef = useRef(0)
 
+  const { height } = useWindowDimensions()
+
   useLayoutEffect(() => {
     if (ref.current) {
       let { top } = ref.current.getBoundingClientRect()
-      let height = window.innerHeight
       // take the inner height of the window, subtract 32 from it (for the bottom padding), then subtract that from the top position of our grid row (wherever that is)
       heightRef.current = height - bottomPad - top
     }
-  }, [bottomPad])
+  }, [bottomPad, height])
 
   return { ref, height: heightRef.current }
 }

--- a/src/hooks/use-computed-height.ts
+++ b/src/hooks/use-computed-height.ts
@@ -1,0 +1,17 @@
+import { useLayoutEffect, useRef } from "react"
+
+export const useComputedHeight = (bottomPad: number) => {
+  const ref = useRef(null)
+  const heightRef = useRef(0)
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      let { top } = ref.current.getBoundingClientRect()
+      let height = window.innerHeight
+      // take the inner height of the window, subtract 32 from it (for the bottom padding), then subtract that from the top position of our grid row (wherever that is)
+      heightRef.current = height - bottomPad - top
+    }
+  }, [bottomPad])
+
+  return { ref, height: heightRef.current }
+}

--- a/src/hooks/use-window-dimensions.ts
+++ b/src/hooks/use-window-dimensions.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react"
+
+export const useWindowDimensions = () => {
+  const [dimensions, setDimensions] = useState({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  })
+
+  useEffect(() => {
+    const handleResize = () => {
+      setDimensions({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      })
+    }
+
+    window.addEventListener("resize", handleResize)
+
+    return () => {
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [])
+
+  return dimensions
+}


### PR DESCRIPTION
## What 

### Fixes two split layout

Both children should have the same height, or in other words, the smaller sibling should follow the larger sibling in terms of height

**Before**
Right pane's height is not equal to left pane's height

![149199153-40256338-bcbb-4ac0-bd2c-090ffe8092c3](https://user-images.githubusercontent.com/33696020/149215795-2b18fef2-15fb-4fff-b7f6-4482baceebc7.jpg)


**After**
Right pane's height is equal to left pane's height

![149199112-a3a648f4-760a-4e5c-85b8-082318dc6c38](https://user-images.githubusercontent.com/33696020/149215817-453c2eea-a6bc-4377-b149-edab4c5c3f9d.jpg)


### Fixes layout

When the content grows beyond a certain height, it overflows the bottom padding initially set by the layout

**Before**
There is no bottom padding when the page is scrolled all the way

![149198692-1f9a41bd-3b95-49d2-a605-59b0213fed5e](https://user-images.githubusercontent.com/33696020/149215827-0c9e1140-8b15-4981-bd1d-f8456139df6f.jpg)

**After**

![149198600-14810719-95ca-4331-9c3c-8a2fed2165b5(1)](https://user-images.githubusercontent.com/33696020/149215840-06e2d7eb-71cc-49a5-a6dc-1d3386857663.jpg)


### Replaces `overflow-y: scroll` by `overflow-y: auto` in Layout

## Why 

- ensures consistency

## How

- **two split pane**: use grid layout as opposed to flex layout. When screen size > medium, we use a 2-column layout, otherwise, we only use one column. 
- **layout**: 
   - remove `height: 100%` from our Layout component's `main` tag and use the default `height: auto` so that it grows with the content.
   - replace `overflow-y: scroll` by `overflow-y: auto` in our `Layout` component. Not entirely sure if it's okay to do that, so let me know what you think! 

Let me know what you guys think as I suspect you might have solved them differently in your on-going tasks @kasperkristensen @pKorsholm @olivermrbl :+1: 