### PR TITLE
Allow control of BodyCard styling

### DIFF
--- a/src/components/organisms/body-card.tsx
+++ b/src/components/organisms/body-card.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx"
 import React from "react"
 import { useScroll } from "../../hooks/use-scroll"
 import Button from "../fundamentals/button"
@@ -11,6 +12,7 @@ type BodyCardProps = {
     onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
   }[]
   actionables?: ActionType[]
+  className?: string
 }
 
 const BodyCard: React.FC<BodyCardProps> = ({
@@ -18,11 +20,17 @@ const BodyCard: React.FC<BodyCardProps> = ({
   subtitle,
   events,
   actionables,
+  className,
   children,
 }) => {
   const { isScrolled, scrollListener } = useScroll({ threshold: 16 })
   return (
-    <div className="rounded-rounded border bg-grey-0 border-grey-20 h-full overflow-hidden flex flex-col min-h-[350px] w-full relative">
+    <div
+      className={clsx(
+        "rounded-rounded border bg-grey-0 border-grey-20 h-full overflow-hidden flex flex-col min-h-[350px] w-full relative",
+        className
+      )}
+    >
       {isScrolled && (
         <div className="absolute top-0 left-0 right-0 bg-gradient-to-b from-grey-0 to-transparent h-xlarge z-10" />
       )}

--- a/src/components/organisms/body-card.tsx
+++ b/src/components/organisms/body-card.tsx
@@ -12,8 +12,7 @@ type BodyCardProps = {
     onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
   }[]
   actionables?: ActionType[]
-  className?: string
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 const BodyCard: React.FC<BodyCardProps> = ({
   title,
@@ -22,6 +21,7 @@ const BodyCard: React.FC<BodyCardProps> = ({
   actionables,
   className,
   children,
+  ...rest
 }) => {
   const { isScrolled, scrollListener } = useScroll({ threshold: 16 })
   return (
@@ -30,6 +30,7 @@ const BodyCard: React.FC<BodyCardProps> = ({
         "rounded-rounded border bg-grey-0 border-grey-20 h-full overflow-hidden flex flex-col min-h-[350px] w-full relative",
         className
       )}
+      {...rest}
     >
       {isScrolled && (
         <div className="absolute top-0 left-0 right-0 bg-gradient-to-b from-grey-0 to-transparent h-xlarge z-10" />

--- a/src/domain/settings/personal-information.tsx
+++ b/src/domain/settings/personal-information.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useContext, useState } from "react"
+import clsx from "clsx"
+import { navigate } from "gatsby"
+import React, { useContext, useState } from "react"
 import { useForm } from "react-hook-form"
-import TwoSplitPane from "../../components/templates/two-split-pane"
-import BodyCard from "../../components/organisms/body-card"
-import BreadCrumb from "../../components/molecules/breadcrumb"
+import Avatar from "../../components/atoms/avatar"
 import Spinner from "../../components/atoms/spinner"
+import BreadCrumb from "../../components/molecules/breadcrumb"
+import Input from "../../components/molecules/input"
+import BodyCard from "../../components/organisms/body-card"
+import FileUploadModal from "../../components/organisms/file-upload-modal"
+import TwoSplitPane from "../../components/templates/two-split-pane"
 import { AccountContext } from "../../context/account"
 import useMedusa from "../../hooks/use-medusa"
-import { navigate } from "gatsby"
 import { getErrorMessage } from "../../utils/error-messages"
-import Input from "../../components/molecules/input"
-import FileUploadModal from "../../components/organisms/file-upload-modal"
-import clsx from "clsx"
-import Avatar from "../../components/atoms/avatar"
 
 const PersonalInformation = () => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
@@ -66,6 +66,7 @@ const PersonalInformation = () => {
           title="Personal information"
           subtitle="Manage your Medusa profile"
           events={events}
+          className={"h-auto max-h-full"}
         >
           <div>
             <span className="inter-base-semibold">Picture</span>
@@ -91,7 +92,6 @@ const PersonalInformation = () => {
               </div>
             </div>
           </div>
-
           <div className="mt-6">
             <span className="inter-base-semibold">General</span>
             <div className="flex mt-4">


### PR DESCRIPTION
Add `className` prop to `BodyCard` to allow for custom styling.

Example use-case:
If the `<BodyCard/>` inside the two-split pane should not always span full height but fit its content until content expands the view, we can set the height to `h-auto` and `max-h-full`.