### PR TITLE
feat: revamp textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-radio-group": "^0.1.4",
     "@rebass/forms": "^4.0.6",
     "@svgr/webpack": "^5.4.0",
+    "@tailwindcss/line-clamp": "^0.3.1",
     "axios": "^0.24.0",
     "clsx": "^1.1.1",
     "copy-to-clipboard": "^3.3.1",

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -305,15 +305,6 @@
   .vice-city {
     @apply bg-gradient-to-tr from-vice-start to-vice-stop;
   }
-  .line-clamp-until-focus {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: var(--lines);
-    
-  }
-  .line-clamp-until-focus:focus {
-    -webkit-line-clamp: unset; 
-  }
 }
 
 /* Classes to remove number spinners from inputs of type number */

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -308,7 +308,7 @@
   .line-clamp-until-focus {
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 4;
+    -webkit-line-clamp: var(--lines);
     
   }
   .line-clamp-until-focus:focus {

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -305,6 +305,15 @@
   .vice-city {
     @apply bg-gradient-to-tr from-vice-start to-vice-stop;
   }
+  .line-clamp-until-focus {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    
+  }
+  .line-clamp-until-focus:focus {
+    -webkit-line-clamp: unset; 
+  }
 }
 
 /* Classes to remove number spinners from inputs of type number */

--- a/src/components/fundamentals/input-container.tsx
+++ b/src/components/fundamentals/input-container.tsx
@@ -23,14 +23,13 @@ const InputContainer: React.FC<InputContainerProps> = ({
       key={key}
       tabIndex={-1}
       onClick={onClick}
-      onBlur={e => {
+      onBlur={(e) => {
         if (onFocusLost && !e.currentTarget.contains(e.relatedTarget)) {
           onFocusLost()
         }
       }}
       className={clsx([
         `bg-grey-5 inter-base-regular w-full p-3 flex h-18 flex-col cursor-text border border-grey-20 focus-within:shadow-input focus-within:border-violet-60 rounded-base`,
-        ,
         className,
       ])}
     >

--- a/src/components/molecules/input/input.stories.tsx
+++ b/src/components/molecules/input/input.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
 import React from "react"
 import Input from "."
 
@@ -7,7 +7,7 @@ export default {
   component: Input,
 } as ComponentMeta<typeof Input>
 
-const Template = args => <Input {...args} />
+const Template: ComponentStory<typeof Input> = (args) => <Input {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/src/components/molecules/textarea/index.tsx
+++ b/src/components/molecules/textarea/index.tsx
@@ -25,7 +25,7 @@ const Textarea = React.forwardRef(
       tooltipProps = {},
       containerProps,
       className,
-      rows = 5,
+      rows = 2,
       ...props
     }: TextareaProps,
     ref

--- a/src/components/molecules/textarea/index.tsx
+++ b/src/components/molecules/textarea/index.tsx
@@ -1,20 +1,11 @@
-import React, {
-  ChangeEventHandler,
-  FocusEventHandler,
-  useImperativeHandle,
-  useRef,
-} from "react"
-import MinusIcon from "../../fundamentals/icons/minus-icon"
-import PlusIcon from "../../fundamentals/icons/plus-icon"
+import clsx from "clsx"
+import React, { useImperativeHandle, useRef } from "react"
 import InputContainer from "../../fundamentals/input-container"
 import InputHeader from "../../fundamentals/input-header"
-import clsx from "clsx"
 
 type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   label: string
   key?: string
-  onChange?: ChangeEventHandler<HTMLTextAreaElement>
-  onFocus?: FocusEventHandler<HTMLTextAreaElement>
   withTooltip?: boolean
   tooltipText?: string
   tooltipProps?: any
@@ -29,46 +20,19 @@ const Textarea = React.forwardRef(
       name,
       key,
       required,
-      onChange,
-      onFocus,
       withTooltip = false,
       tooltipText,
       tooltipProps = {},
       containerProps,
       className,
+      rows = 5,
       ...props
     }: TextareaProps,
     ref
   ) => {
-    const inputRef = useRef(null)
+    const inputRef = useRef<HTMLTextAreaElement>(null)
 
     useImperativeHandle(ref, () => inputRef.current)
-
-    const onClickChevronUp = () => {
-      inputRef.current?.stepUp()
-      if (onChange) {
-        inputRef.current?.dispatchEvent(
-          new InputEvent("change", {
-            view: window,
-            bubbles: true,
-            cancelable: false,
-          })
-        )
-      }
-    }
-
-    const onClickChevronDown = () => {
-      inputRef.current?.stepDown()
-      if (onChange) {
-        inputRef.current?.dispatchEvent(
-          new InputEvent("change", {
-            view: window,
-            bubbles: true,
-            cancelable: false,
-          })
-        )
-      }
-    }
 
     const scrollToTop = () => {
       if (inputRef.current) {
@@ -95,15 +59,18 @@ const Textarea = React.forwardRef(
               "w-full remove-number-spinner leading-base text-grey-90 font-normal caret-violet-60 placeholder-grey-40",
               "line-clamp-until-focus"
             )}
+            style={
+              {
+                "--lines": rows,
+              } as React.CSSProperties
+            }
             ref={inputRef}
             autoComplete="off"
             name={name}
             key={key || name}
             placeholder={placeholder || "Placeholder"}
-            onChange={onChange}
-            onFocus={onFocus}
             onBlur={scrollToTop}
-            rows={4}
+            rows={rows}
             {...props}
           />
         </div>

--- a/src/components/molecules/textarea/index.tsx
+++ b/src/components/molecules/textarea/index.tsx
@@ -1,0 +1,115 @@
+import React, {
+  ChangeEventHandler,
+  FocusEventHandler,
+  useImperativeHandle,
+  useRef,
+} from "react"
+import MinusIcon from "../../fundamentals/icons/minus-icon"
+import PlusIcon from "../../fundamentals/icons/plus-icon"
+import InputContainer from "../../fundamentals/input-container"
+import InputHeader from "../../fundamentals/input-header"
+import clsx from "clsx"
+
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  label: string
+  key?: string
+  onChange?: ChangeEventHandler<HTMLTextAreaElement>
+  onFocus?: FocusEventHandler<HTMLTextAreaElement>
+  withTooltip?: boolean
+  tooltipText?: string
+  tooltipProps?: any
+  containerProps?: React.HTMLAttributes<HTMLDivElement>
+}
+
+const Textarea = React.forwardRef(
+  (
+    {
+      placeholder,
+      label,
+      name,
+      key,
+      required,
+      onChange,
+      onFocus,
+      withTooltip = false,
+      tooltipText,
+      tooltipProps = {},
+      containerProps,
+      className,
+      ...props
+    }: TextareaProps,
+    ref
+  ) => {
+    const inputRef = useRef(null)
+
+    useImperativeHandle(ref, () => inputRef.current)
+
+    const onClickChevronUp = () => {
+      inputRef.current?.stepUp()
+      if (onChange) {
+        inputRef.current?.dispatchEvent(
+          new InputEvent("change", {
+            view: window,
+            bubbles: true,
+            cancelable: false,
+          })
+        )
+      }
+    }
+
+    const onClickChevronDown = () => {
+      inputRef.current?.stepDown()
+      if (onChange) {
+        inputRef.current?.dispatchEvent(
+          new InputEvent("change", {
+            view: window,
+            bubbles: true,
+            cancelable: false,
+          })
+        )
+      }
+    }
+
+    const scrollToTop = () => {
+      if (inputRef.current) {
+        inputRef.current.scrollTop = 0
+      }
+    }
+
+    return (
+      <InputContainer
+        className={className}
+        key={name}
+        onClick={() => inputRef?.current?.focus()}
+        {...containerProps}
+      >
+        {label && (
+          <InputHeader
+            {...{ label, required, withTooltip, tooltipText, tooltipProps }}
+          />
+        )}
+        <div className="w-full flex mt-1">
+          <textarea
+            className={clsx(
+              "relative text-justify overflow-hidden focus:overflow-auto resize-none bg-inherit outline-none outline-0",
+              "w-full remove-number-spinner leading-base text-grey-90 font-normal caret-violet-60 placeholder-grey-40",
+              "line-clamp-until-focus"
+            )}
+            ref={inputRef}
+            autoComplete="off"
+            name={name}
+            key={key || name}
+            placeholder={placeholder || "Placeholder"}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={scrollToTop}
+            rows={4}
+            {...props}
+          />
+        </div>
+      </InputContainer>
+    )
+  }
+)
+
+export default Textarea

--- a/src/components/molecules/textarea/index.tsx
+++ b/src/components/molecules/textarea/index.tsx
@@ -57,7 +57,7 @@ const Textarea = React.forwardRef(
             className={clsx(
               "relative text-justify overflow-hidden focus:overflow-auto resize-none bg-inherit outline-none outline-0",
               "w-full remove-number-spinner leading-base text-grey-90 font-normal caret-violet-60 placeholder-grey-40",
-              "line-clamp-until-focus"
+              "line-clamp-[var(--lines)] focus:line-clamp-none"
             )}
             style={
               {

--- a/src/components/molecules/textarea/textarea.stories.tsx
+++ b/src/components/molecules/textarea/textarea.stories.tsx
@@ -11,21 +11,31 @@ const Template: ComponentStory<typeof Textarea> = (args) => (
   <Textarea {...args} />
 )
 
-export const Default = Template.bind({})
-Default.args = {
+export const Short = Template.bind({})
+Short.args = {
+  rows: 2,
   label: "Description",
-  placeholder: "Long description",
-  value:
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote",
-  rows: 4,
+  placeholder: "Normal",
+  value: "Lorem ipsum something pretty basic ",
+  required: false,
 }
 
-export const Required = Template.bind({})
-Required.args = {
+export const Overflow = Template.bind({})
+Overflow.args = {
+  rows: 2,
   label: "Description",
   placeholder: "Long description",
   value:
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote",
-  rows: 2,
-  required: true,
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  required: false,
+}
+
+export const DynamicClamping = Template.bind({})
+DynamicClamping.args = {
+  rows: 4,
+  label: "Description",
+  placeholder: "Long description",
+  value:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote ",
+  required: false,
 }

--- a/src/components/molecules/textarea/textarea.stories.tsx
+++ b/src/components/molecules/textarea/textarea.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
 import React from "react"
 import Textarea from "."
 
@@ -7,17 +7,25 @@ export default {
   component: Textarea,
 } as ComponentMeta<typeof Textarea>
 
-const Template = (args) => <Textarea {...args} />
+const Template: ComponentStory<typeof Textarea> = (args) => (
+  <Textarea {...args} />
+)
 
 export const Default = Template.bind({})
 Default.args = {
   label: "Description",
-  placeholder: "LeBron James",
+  placeholder: "Long description",
+  value:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote",
+  rows: 4,
 }
 
 export const Required = Template.bind({})
 Required.args = {
   label: "Description",
+  placeholder: "Long description",
+  value:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis lacus vitae velit tristique varius at sed sapien. Sed bibendum interdum imperdiet. Etiam et maximus libero. Ut fringilla velit non ultricies pulvinar. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed placerat metus a dui viverra, ut elementum tortor rutrum. Suspendisse pote",
+  rows: 2,
   required: true,
-  placeholder: "lebron@james.com",
 }

--- a/src/components/molecules/textarea/textarea.stories.tsx
+++ b/src/components/molecules/textarea/textarea.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta } from "@storybook/react"
+import React from "react"
+import Textarea from "."
+
+export default {
+  title: "Molecules/Textarea",
+  component: Textarea,
+} as ComponentMeta<typeof Textarea>
+
+const Template = (args) => <Textarea {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  label: "Description",
+  placeholder: "LeBron James",
+}
+
+export const Required = Template.bind({})
+Required.args = {
+  label: "Description",
+  required: true,
+  placeholder: "lebron@james.com",
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -249,7 +249,10 @@ module.exports = {
       animation: {
         ring: "ring 2.2s cubic-bezier(0.5, 0, 0.5, 1) infinite",
       },
+      lineClamp: {
+        "[var(--lines)]": "var(--lines)",
+      },
     },
   },
-  plugins: [],
+  plugins: [require("@tailwindcss/line-clamp")],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3742,6 +3742,11 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tailwindcss/line-clamp@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz#4d8441b509b87ece84e94f28a4aa9998413ab849"
+  integrity sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg==
+
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"


### PR DESCRIPTION
### What
- adds textarea 
- adds a story for textarea
- fixes typescript errors + prettier for `InputContainer` and `input.stories.tsx`

### How
- used @pKorsholm's work on `Input` as reference
- used `@tailwindcss/line-clamp` (thanks @kasperkristensen!) and extended it with a custom class to allow for dynamic values in `line-clamp` based on textarea's `rows` value

_Note: clamping the multiline textarea works by using the [line-clamp css property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp). I noticed some issues with it when using Firefox, but as far as I have tried, it works well with Chrome and Brave. So please if you have Safari/Firefox, try to run it there and see if the clamping behaves as expected._ 