### PR TITLE
add: tooltip + stories + adapt input

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,8 @@
+<style>
+  html, body {
+    height: 100%;
+  }
+  #root {
+    height: 100%;
+  }
+</style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,4 @@
+<!-- allows stories to expand the full viewport when needed-->
 <style>
   html, body {
     height: 100%;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-dialog": "^0.1.5",
     "@radix-ui/react-dropdown-menu": "^0.1.4",
     "@radix-ui/react-radio-group": "^0.1.4",
+    "@radix-ui/react-tooltip": "^0.1.6",
     "@rebass/forms": "^4.0.6",
     "@svgr/webpack": "^5.4.0",
     "axios": "^0.24.0",

--- a/src/components/atoms/tooltip/index.tsx
+++ b/src/components/atoms/tooltip/index.tsx
@@ -1,0 +1,51 @@
+import * as RadixTooltip from "@radix-ui/react-tooltip"
+import clsx from "clsx"
+
+type TooltipProps = RadixTooltip.TooltipContentProps &
+  Pick<
+    RadixTooltip.TooltipProps,
+    "open" | "defaultOpen" | "onOpenChange" | "delayDuration"
+  > & {
+    content: string
+  }
+
+const Tooltip = ({
+  children,
+  content,
+  open,
+  defaultOpen,
+  onOpenChange,
+  delayDuration,
+  className,
+  ...props
+}: TooltipProps) => {
+  return (
+    <RadixTooltip.Provider delayDuration={100}>
+      <RadixTooltip.Root
+        open={open}
+        defaultOpen={defaultOpen}
+        onOpenChange={onOpenChange}
+        delayDuration={delayDuration}
+      >
+        <RadixTooltip.Trigger>{children}</RadixTooltip.Trigger>
+        <RadixTooltip.Content
+          side="bottom"
+          sideOffset={8}
+          align="center"
+          className={clsx(
+            "inter-small-semibold text-grey-50 text-center",
+            "bg-grey-5 py-[6px] px-[12px] shadow-dropdown rounded",
+            "border border-solid border-grey-20",
+            "max-w-[220px]",
+            className
+          )}
+          {...props}
+        >
+          {content}
+        </RadixTooltip.Content>
+      </RadixTooltip.Root>
+    </RadixTooltip.Provider>
+  )
+}
+
+export default Tooltip

--- a/src/components/atoms/tooltip/tooltip.stories.tsx
+++ b/src/components/atoms/tooltip/tooltip.stories.tsx
@@ -46,7 +46,7 @@ const Template: ComponentStory<any> = ({ triggerPosition, ...props }) => {
       )}
     >
       <Tooltip {...props}>
-        <button>hover!</button>
+        <button className="btn btn-secondary btn-medium">hover!</button>
       </Tooltip>
     </div>
   )

--- a/src/components/atoms/tooltip/tooltip.stories.tsx
+++ b/src/components/atoms/tooltip/tooltip.stories.tsx
@@ -1,0 +1,66 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+import React from "react"
+import Tooltip from "."
+import clsx from "clsx"
+
+export default {
+  title: "Molecules/Tooltip",
+  component: Tooltip,
+  argTypes: {
+    triggerPosition: {
+      options: [
+        "top left",
+        "top right",
+        "top center",
+        "center center",
+        "center right",
+        "center left",
+        "bottom left",
+        "bottom right",
+        "bottom center",
+      ],
+      control: {
+        type: "select",
+      },
+      defaultValue: "top left",
+    },
+  },
+} as ComponentMeta<typeof Tooltip>
+
+const Template: ComponentStory<any> = ({ triggerPosition, ...props }) => {
+  return (
+    <div
+      className={clsx(
+        {
+          ["justify-start content-start"]: triggerPosition === "top left",
+          ["justify-center content-start"]: triggerPosition === "top center",
+          ["justify-end content-start"]: triggerPosition === "top right",
+          ["justify-start content-center"]: triggerPosition === "center left",
+          ["place-content-center"]: triggerPosition === "center center",
+          ["justify-end content-center"]: triggerPosition === "center right",
+          ["justify-start content-end"]: triggerPosition === "bottom left",
+          ["justify-center content-end"]: triggerPosition === "bottom center",
+          ["justify-end content-end"]: triggerPosition === "bottom right",
+        },
+        "min-h-full grid"
+      )}
+    >
+      <Tooltip {...props}>
+        <button>hover!</button>
+      </Tooltip>
+    </div>
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  content: "Tags are one word descriptors for the product used for searches",
+  sideOffset: 10,
+}
+
+export const Controlled = Template.bind({})
+Controlled.args = {
+  open: true,
+  content: "Tags are one word descriptors for the product used for searches",
+  sideOffset: 10,
+}

--- a/src/components/fundamentals/icons/alert-icon/alert-icon.stories.tsx
+++ b/src/components/fundamentals/icons/alert-icon/alert-icon.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+import React from "react"
+import AlertIcon from "."
+
+export default {
+  title: "Fundamentals/Icons/AlertIcon",
+  component: AlertIcon,
+  argTypes: {
+    size: {
+      control: {
+        type: "select",
+        options: ["24", "20", "16"],
+      },
+    },
+  },
+} as ComponentMeta<typeof AlertIcon>
+
+const Template: ComponentStory<typeof AlertIcon> = (args) => (
+  <AlertIcon {...args} />
+)
+
+export const Icon = Template.bind({})
+Icon.args = {
+  size: "24",
+  color: "currentColor",
+}

--- a/src/components/fundamentals/icons/alert-icon/index.tsx
+++ b/src/components/fundamentals/icons/alert-icon/index.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import IconProps from "../types/icon-type"
+
+const AlertIcon: React.FC<IconProps> = ({
+  size = "20",
+  color = "currentColor",
+  ...attributes
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...attributes}
+    >
+      <path
+        d="M10 17.5C14.1421 17.5 17.5 14.1421 17.5 10C17.5 5.85786 14.1421 2.5 10 2.5C5.85786 2.5 2.5 5.85786 2.5 10C2.5 14.1421 5.85786 17.5 10 17.5Z"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M10 6.66669V10"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M10 13.3333H10.0088"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default AlertIcon

--- a/src/components/fundamentals/icons/info-icon/index.tsx
+++ b/src/components/fundamentals/icons/info-icon/index.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import IconProps from "../types/icon-type"
+
+const InfoIcon: React.FC<IconProps> = ({
+  size = "16",
+  color = "currentColor",
+  ...attributes
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...attributes}
+    >
+      <path
+        d="M8 14C11.3137 14 14 11.3137 14 8C14 4.68629 11.3137 2 8 2C4.68629 2 2 4.68629 2 8C2 11.3137 4.68629 14 8 14Z"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M8 10.6667V8"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M8 5.33331H8.0075"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default InfoIcon

--- a/src/components/fundamentals/icons/info-icon/info-icon.stories.tsx
+++ b/src/components/fundamentals/icons/info-icon/info-icon.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+import React from "react"
+import InfoIcon from "."
+
+export default {
+  title: "Fundamentals/Icons/InfoIcon",
+  component: InfoIcon,
+  argTypes: {
+    size: {
+      control: {
+        type: "select",
+        options: ["24", "20", "16"],
+      },
+    },
+  },
+} as ComponentMeta<typeof InfoIcon>
+
+const Template: ComponentStory<typeof InfoIcon> = (args) => (
+  <InfoIcon {...args} />
+)
+
+export const Icon = Template.bind({})
+Icon.args = {
+  size: "24",
+  color: "currentColor",
+}

--- a/src/components/fundamentals/input-header.tsx
+++ b/src/components/fundamentals/input-header.tsx
@@ -5,7 +5,7 @@ export type InputHeaderProps = {
   label: string
   required?: boolean
   tooltipContent?: string
-  tooltip?: any
+  tooltip?: React.ReactNode
 }
 
 const InputHeader: React.FC<InputHeaderProps> = ({

--- a/src/components/fundamentals/input-header.tsx
+++ b/src/components/fundamentals/input-header.tsx
@@ -1,28 +1,26 @@
 import React from "react"
-import InfoTooltip from "../info-tooltip"
+import InfoTooltip from "../molecules/info-tooltip"
 
-type InputHeaderProps = {
+export type InputHeaderProps = {
   label: string
   required?: boolean
-  withTooltip?: boolean
-  tooltipText?: string
-  tooltipProps?: any
+  tooltipContent?: string
+  tooltip?: any
 }
 
 const InputHeader: React.FC<InputHeaderProps> = ({
   label,
   required = false,
-  withTooltip = false,
-  tooltipText,
-  tooltipProps,
+  tooltipContent,
+  tooltip,
 }) => {
   return (
     <div className="w-full flex inter-small-semibold text-grey-50 items-center">
-      {label}
+      <label>{label}</label>
       {required && <div className="text-rose-50 "> *</div>}
-      {withTooltip ? (
-        <div className="ml-2">
-          <InfoTooltip tooltipText={tooltipText} {...tooltipProps} />
+      {tooltip || tooltipContent ? (
+        <div className="flex ml-1.5">
+          {tooltip || <InfoTooltip content={tooltipContent} />}
         </div>
       ) : null}
     </div>

--- a/src/components/molecules/info-tooltip/index.tsx
+++ b/src/components/molecules/info-tooltip/index.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import Tooltip from "../../atoms/tooltip"
+import InfoIcon from "../../fundamentals/icons/info-icon"
+
+const InfoTooltip = ({ content, ...props }) => {
+  return (
+    <Tooltip content={content} {...props}>
+      <InfoIcon className="flex text-grey-40" />
+    </Tooltip>
+  )
+}
+
+export default InfoTooltip

--- a/src/components/molecules/info-tooltip/info-tooltip.stories.tsx
+++ b/src/components/molecules/info-tooltip/info-tooltip.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+import React from "react"
+import Input from "."
+import InfoTooltip from "."
+
+export default {
+  title: "Molecules/InfoTooltip",
+  component: InfoTooltip,
+} as ComponentMeta<typeof InfoTooltip>
+
+const Template: ComponentStory<typeof InfoTooltip> = (args) => (
+  <Input {...args} />
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  content: "Tags are one word descriptors for the product used for searches",
+}

--- a/src/components/molecules/input/index.tsx
+++ b/src/components/molecules/input/index.tsx
@@ -8,20 +8,18 @@ import React, {
 import MinusIcon from "../../fundamentals/icons/minus-icon"
 import PlusIcon from "../../fundamentals/icons/plus-icon"
 import InputContainer from "../../fundamentals/input-container"
-import InputHeader from "../../fundamentals/input-header"
+import InputHeader, { InputHeaderProps } from "../../fundamentals/input-header"
 
-type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
-  label: string
-  deletable?: boolean
-  key?: string
-  onDelete?: MouseEventHandler<HTMLSpanElement>
-  onChange?: ChangeEventHandler<HTMLInputElement>
-  onFocus?: FocusEventHandler<HTMLInputElement>
-  withTooltip?: boolean
-  tooltipText?: string
-  tooltipProps?: any
-  props?: React.HTMLAttributes<HTMLDivElement>
-}
+type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
+  InputHeaderProps & {
+    label?: string
+    deletable?: boolean
+    key?: string
+    onDelete?: MouseEventHandler<HTMLSpanElement>
+    onChange?: ChangeEventHandler<HTMLInputElement>
+    onFocus?: FocusEventHandler<HTMLInputElement>
+    props?: React.HTMLAttributes<HTMLDivElement>
+  }
 
 const InputField = React.forwardRef(
   (
@@ -35,9 +33,8 @@ const InputField = React.forwardRef(
       onDelete,
       onChange,
       onFocus,
-      withTooltip = false,
-      tooltipText,
-      tooltipProps = {},
+      tooltipContent,
+      tooltip,
       props,
       className,
       ...fieldProps
@@ -82,9 +79,7 @@ const InputField = React.forwardRef(
         {...props}
       >
         {label && (
-          <InputHeader
-            {...{ label, required, withTooltip, tooltipText, tooltipProps }}
-          />
+          <InputHeader {...{ label, required, tooltipContent, tooltip }} />
         )}
         <div className="w-full flex mt-1">
           <input
@@ -109,13 +104,13 @@ const InputField = React.forwardRef(
             <div className="flex self-end">
               <span
                 onClick={onClickChevronDown}
-                onMouseDown={e => e.preventDefault()}
+                onMouseDown={(e) => e.preventDefault()}
                 className="mr-2 text-grey-50 w-4 h-4 hover:bg-grey-10 rounded-soft cursor-pointer"
               >
                 <MinusIcon size={16} />
               </span>
               <span
-                onMouseDown={e => e.preventDefault()}
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={onClickChevronUp}
                 className="text-grey-50 w-4 h-4 hover:bg-grey-10 rounded-soft cursor-pointer"
               >

--- a/src/components/molecules/input/input.stories.tsx
+++ b/src/components/molecules/input/input.stories.tsx
@@ -32,10 +32,10 @@ WithInfoTooltip.args = {
 
 export const WithCustomTooltip = Template.bind({})
 WithCustomTooltip.args = {
-  label: "Something",
+  label: "Tricky",
   tooltip: (
     <Tooltip
-      content={"This action will mess up your entire ordering system!!!"}
+      content={"Changing this might cause bad luck"}
       className="text-rose-50"
       side="right"
       align="end"

--- a/src/components/molecules/input/input.stories.tsx
+++ b/src/components/molecules/input/input.stories.tsx
@@ -24,8 +24,6 @@ Required.args = {
   placeholder: "lebron@james.com",
 }
 
-// Not currently part of the new design
-
 export const WithInfoTooltip = Template.bind({})
 WithInfoTooltip.args = {
   label: "Default",

--- a/src/components/molecules/input/input.stories.tsx
+++ b/src/components/molecules/input/input.stories.tsx
@@ -1,13 +1,15 @@
-import { ComponentMeta } from "@storybook/react"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
 import React from "react"
 import Input from "."
+import Tooltip from "../../atoms/tooltip"
+import AlertIcon from "../../fundamentals/icons/alert-icon"
 
 export default {
   title: "Molecules/Input",
   component: Input,
 } as ComponentMeta<typeof Input>
 
-const Template = args => <Input {...args} />
+const Template: ComponentStory<typeof Input> = (args) => <Input {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -24,9 +26,23 @@ Required.args = {
 
 // Not currently part of the new design
 
-// export const WithToolTip = Template.bind({})
-// WithToolTip.args = {
-//   label: "Default",
-//   withTooltip: true,
-//   tooltipText: "This is a tooltip",
-// }
+export const WithInfoTooltip = Template.bind({})
+WithInfoTooltip.args = {
+  label: "Default",
+  tooltipContent: "This is a tooltip",
+}
+
+export const WithCustomTooltip = Template.bind({})
+WithCustomTooltip.args = {
+  label: "Something",
+  tooltip: (
+    <Tooltip
+      content={"This action will mess up your entire ordering system!!!"}
+      className="text-rose-50"
+      side="right"
+      align="end"
+    >
+      <AlertIcon size={16} className="flex text-rose-50" />
+    </Tooltip>
+  ),
+}

--- a/src/components/organisms/sidebar/sidebar.stories.tsx
+++ b/src/components/organisms/sidebar/sidebar.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
 import React from "react"
 import Sidebar from "."
 
@@ -7,7 +7,7 @@ export default {
   component: Sidebar,
 } as ComponentMeta<typeof Sidebar>
 
-const Template = args => <Sidebar {...args} />
+const Template: ComponentStory<typeof Sidebar> = (args) => <Sidebar {...args} />
 
 export const Default = Template.bind({})
 Default.args = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,6 +2554,27 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "0.1.0"
 
+"@radix-ui/react-tooltip@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-0.1.6.tgz#46a3e385e004aaebd16ecaa1da7d1af70ba3bb45"
+  integrity sha512-0uaRpRmTCQo5yMUkDpv4LEDnaQDoeLXcNNhZonCZdbZBQ7ntvjURIWIigq1/pXZp0UX7oPpFzsXD9jUp8JT0WA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-id" "0.1.4"
+    "@radix-ui/react-popper" "0.1.3"
+    "@radix-ui/react-portal" "0.1.3"
+    "@radix-ui/react-presence" "0.1.1"
+    "@radix-ui/react-primitive" "0.1.3"
+    "@radix-ui/react-slot" "0.1.2"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+    "@radix-ui/react-use-escape-keydown" "0.1.0"
+    "@radix-ui/react-use-previous" "0.1.0"
+    "@radix-ui/react-use-rect" "0.1.1"
+    "@radix-ui/react-visually-hidden" "0.1.3"
+
 "@radix-ui/react-use-body-pointer-events@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.0.tgz#29b211464493f8ca5149ce34b96b95abbc97d741"
@@ -2620,6 +2641,14 @@
   integrity sha512-TcZAsR+BYI46w/RbaSFCRACl+Jh6mDqhu6GS2r0iuJpIVrj8atff7qtTjmMmfGtEDNEjhl7DxN3pr1nTS/oruQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-visually-hidden@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-0.1.3.tgz#406a2f1e2f2cf27e5b85a29dc3aca718e695acaf"
+  integrity sha512-dPU6ZR2WQ/W9qv7E1Y8/I8ymqG+8sViU6dQQ6sfr2/8yGr0I4mmI7ywTnqXaE+YS9gHLEZHdQcEqTNESg6YfdQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "0.1.3"
 
 "@radix-ui/rect@0.1.1":
   version "0.1.1"


### PR DESCRIPTION
### What

- adds a generic tooltip component
- adds an info tooltip component (a tooltip which has an info icon as a trigger)
- adapts the `Input` component to use an info tooltip next to its label
- adds info + alert icons and their stories
- adds stories for tooltips
- adds a story for info tooltip
- adds a story for an input with tooltip
- adds a story for an input with custom tooltip

### How 
-  uses Radix's tooltip component

