### PR TITLE
Updated: devcert dependency version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "@medusajs",
   "resolutions": {
-    "devcert": "1.1.0"
+    "devcert": "1.1.1"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",


### PR DESCRIPTION
closes #255 

**What changes PR consists?**
Changed devcert dependency version

**Why the changes are made?**
As the package has remote execution vulnerability in version <= 1.1.0