### PR TITLE
feat: DetailsCollapsible

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^10.0.27",
     "@popperjs/core": "^2.10.2",
     "@radix-ui/react-avatar": "^0.1.3",
+    "@radix-ui/react-collapsible": "^0.1.5",
     "@radix-ui/react-dialog": "^0.1.5",
     "@radix-ui/react-dropdown-menu": "^0.1.4",
     "@radix-ui/react-radio-group": "^0.1.4",

--- a/src/components/organisms/details-collapsible/details-collapsible.stories.tsx
+++ b/src/components/organisms/details-collapsible/details-collapsible.stories.tsx
@@ -20,4 +20,11 @@ Component.args = {
       <Input label="Subtitle" name="subtitle" placeholder="Add a subtitle" />
     </div>
   ),
+  triggerProps: {
+    className: "ml-2",
+  },
+  contentProps: {
+    className: "px-6",
+  },
+  rootProps: {},
 }

--- a/src/components/organisms/details-collapsible/details-collapsible.stories.tsx
+++ b/src/components/organisms/details-collapsible/details-collapsible.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+import React from "react"
+import DetailsCollapsible from "."
+import Input from "../../molecules/input"
+
+export default {
+  title: "Organisms/DetailsCollapsible",
+  component: DetailsCollapsible,
+} as ComponentMeta<typeof DetailsCollapsible>
+
+const Template: ComponentStory<typeof DetailsCollapsible> = (args) => (
+  <DetailsCollapsible {...args} />
+)
+
+export const Component = Template.bind({})
+Component.args = {
+  children: (
+    <div className="flex flex-col w-1/2 space-y-4">
+      <Input label="Handle" name="handle" value="medusa-t-shirt" />
+      <Input label="Subtitle" name="subtitle" placeholder="Add a subtitle" />
+    </div>
+  ),
+}

--- a/src/components/organisms/details-collapsible/index.tsx
+++ b/src/components/organisms/details-collapsible/index.tsx
@@ -4,21 +4,41 @@ import React, { useState } from "react"
 import ArrowDownIcon from "../../fundamentals/icons/arrow-down-icon"
 import ArrowUpIcon from "../../fundamentals/icons/arrow-up-icon"
 
-const DetailsCollapsible = ({ children }) => {
+type DetailsCollapsibleProps = {
+  rootProps?: RadixCollapsible.CollapsibleProps
+  triggerProps?: RadixCollapsible.CollapsibleTriggerProps
+  contentProps?: RadixCollapsible.CollapsibleContentProps
+  children: React.ReactNode
+}
+
+const DetailsCollapsible = ({
+  rootProps,
+  triggerProps,
+  contentProps,
+  children,
+}: DetailsCollapsibleProps) => {
   const [open, setOpen] = useState(false)
 
   const Icon = open ? ArrowUpIcon : ArrowDownIcon
   const label = open ? "Hide additional details" : "Show additional details"
 
   return (
-    <RadixCollapsible.Root onOpenChange={(state) => setOpen(state)}>
-      <RadixCollapsible.Trigger className={clsx("ml-4", { ["mb-6"]: open })}>
+    <RadixCollapsible.Root
+      {...rootProps}
+      onOpenChange={(state) => setOpen(state)}
+    >
+      <RadixCollapsible.Trigger
+        {...triggerProps}
+        className={clsx({ ["mb-6"]: open }, triggerProps?.className)}
+      >
         <div className="flex items-center">
           <Icon size={"20"} />
           <div className="ml-1">{label}</div>
         </div>
       </RadixCollapsible.Trigger>
-      <RadixCollapsible.Content>{children}</RadixCollapsible.Content>
+      <RadixCollapsible.Content {...contentProps}>
+        {children}
+      </RadixCollapsible.Content>
     </RadixCollapsible.Root>
   )
 }

--- a/src/components/organisms/details-collapsible/index.tsx
+++ b/src/components/organisms/details-collapsible/index.tsx
@@ -1,0 +1,26 @@
+import * as RadixCollapsible from "@radix-ui/react-collapsible"
+import clsx from "clsx"
+import React, { useState } from "react"
+import ArrowDownIcon from "../../fundamentals/icons/arrow-down-icon"
+import ArrowUpIcon from "../../fundamentals/icons/arrow-up-icon"
+
+const DetailsCollapsible = ({ children }) => {
+  const [open, setOpen] = useState(false)
+
+  const Icon = open ? ArrowUpIcon : ArrowDownIcon
+  const label = open ? "Hide additional details" : "Show additional details"
+
+  return (
+    <RadixCollapsible.Root onOpenChange={(state) => setOpen(state)}>
+      <RadixCollapsible.Trigger className={clsx("ml-4", { ["mb-6"]: open })}>
+        <div className="flex items-center">
+          <Icon size={"20"} />
+          <div className="ml-1">{label}</div>
+        </div>
+      </RadixCollapsible.Trigger>
+      <RadixCollapsible.Content>{children}</RadixCollapsible.Content>
+    </RadixCollapsible.Root>
+  )
+}
+
+export default DetailsCollapsible

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,6 +2340,21 @@
     "@radix-ui/react-use-callback-ref" "0.1.0"
     "@radix-ui/react-use-layout-effect" "0.1.0"
 
+"@radix-ui/react-collapsible@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-0.1.5.tgz#086ebc9fb6ee35035dc3e755fa6940bc5b1e5206"
+  integrity sha512-jhj0h+gGc04D04mQW1zJgBxMJecYV21XaeyghjyXtp+ObM4EHkXnfOA5MyRMzSNB4u8wQ6P1zGtAbxHz1A4Vvg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-id" "0.1.4"
+    "@radix-ui/react-presence" "0.1.1"
+    "@radix-ui/react-primitive" "0.1.3"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
+
 "@radix-ui/react-collection@0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-0.1.3.tgz#7b584f5db40ce165883b87c383d3bd16c0000d69"


### PR DESCRIPTION
**What**
Adds a collapsible organism for showing/hiding details.

**How**
Use `@radix-ui/collapsible`

Decided to add this as an organism, since it's already being used multiple times in the design. Considered adding a more generic collapsible molecule, but Radix UI's collapsible is already quite customizable, so did not find this relevant. Alternatively, we could also completely remove this component and use Radix directly. Let me know, what you think :) 