### PR TITLE
fix: custom actionables

### DIFF
--- a/src/components/molecules/actionables.tsx
+++ b/src/components/molecules/actionables.tsx
@@ -14,7 +14,7 @@ export type ActionType = {
 type ActionablesProps = {
   actions?: ActionType[]
   customTrigger?: React.ReactNode
-  forceDots?: boolean
+  forceDropdown?: boolean
 }
 
 /**
@@ -24,13 +24,13 @@ type ActionablesProps = {
 const Actionables: React.FC<ActionablesProps> = ({
   actions,
   customTrigger,
-  forceDots = false,
+  forceDropdown = false,
 }) => {
   if (!actions?.length) {
     return null
   }
 
-  return actions.length > 1 || forceDots ? (
+  return actions.length > 1 || forceDropdown ? (
     <div>
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>

--- a/src/components/molecules/actionables.tsx
+++ b/src/components/molecules/actionables.tsx
@@ -13,28 +13,38 @@ export type ActionType = {
 
 type ActionablesProps = {
   actions?: ActionType[]
+  customTrigger?: React.ReactNode
+  forceDots?: boolean
 }
 
 /**
  * A component that accepts multiple actionables and renders them as a dropdown menu.
  * If only a single actionable is provided, it will render a button instead.
  */
-const Actionables: React.FC<ActionablesProps> = ({ actions }) => {
+const Actionables: React.FC<ActionablesProps> = ({
+  actions,
+  customTrigger,
+  forceDots = false,
+}) => {
   if (!actions?.length) {
     return null
   }
 
-  return actions.length > 1 ? (
+  return actions.length > 1 || forceDots ? (
     <div>
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
-          <Button
-            variant="ghost"
-            size="small"
-            className="w-xlarge h-xlarge focus:border-none focus:shadow-none"
-          >
-            <MoreHorizontalIcon size={20} />
-          </Button>
+          {!customTrigger ? (
+            <Button
+              variant="ghost"
+              size="small"
+              className="w-xlarge h-xlarge focus:border-none focus:shadow-none"
+            >
+              <MoreHorizontalIcon size={20} />
+            </Button>
+          ) : (
+            <div>{customTrigger}</div>
+          )}
         </DropdownMenu.Trigger>
 
         <DropdownMenu.Content
@@ -64,10 +74,16 @@ const Actionables: React.FC<ActionablesProps> = ({ actions }) => {
       </DropdownMenu.Root>
     </div>
   ) : (
-    <Button variant="ghost" size="small" onClick={actions[0].onClick}>
-      {actions[0].icon}
-      {actions[0].label}
-    </Button>
+    <div>
+      {customTrigger ? (
+        <div>{customTrigger}</div>
+      ) : (
+        <Button variant="ghost" size="small" onClick={actions[0].onClick}>
+          {actions[0].icon}
+          {actions[0].label}
+        </Button>
+      )}
+    </div>
   )
 }
 

--- a/src/components/organisms/body-card.tsx
+++ b/src/components/organisms/body-card.tsx
@@ -56,7 +56,7 @@ const BodyCard: React.FC<BodyCardProps> = ({
             {status && status}
             <Actionables
               actions={actionables}
-              forceDots={forceDropdown}
+              forceDropdown={forceDropdown}
               customTrigger={customActionable}
             />
           </div>

--- a/src/components/organisms/body-card.tsx
+++ b/src/components/organisms/body-card.tsx
@@ -13,6 +13,8 @@ type BodyCardProps = {
     type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"]
   }[]
   actionables?: ActionType[]
+  forceDropdown?: boolean
+  customActionable?: React.ReactNode
   status?: React.ReactNode
 } & React.HTMLAttributes<HTMLDivElement>
 
@@ -21,6 +23,8 @@ const BodyCard: React.FC<BodyCardProps> = ({
   subtitle,
   events,
   actionables,
+  forceDropdown = false,
+  customActionable,
   status,
   className,
   children,
@@ -50,7 +54,11 @@ const BodyCard: React.FC<BodyCardProps> = ({
           )}
           <div className="flex items-center space-x-2">
             {status && status}
-            <Actionables actions={actionables} />
+            <Actionables
+              actions={actionables}
+              forceDots={forceDropdown}
+              customTrigger={customActionable}
+            />
           </div>
         </div>
         {subtitle && (

--- a/src/domain/settings/regions/index.tsx
+++ b/src/domain/settings/regions/index.tsx
@@ -76,14 +76,14 @@ const Regions = () => {
                 value={selectedRegion}
                 onValueChange={setSelectedRegion}
               >
-                {regions.map(r => {
+                {regions.map((r) => {
                   const providers = `Payment providers: ${
                     r.payment_providers
-                      .map(pp => paymentProvidersMapper(pp.id).label)
+                      .map((pp) => paymentProvidersMapper(pp.id).label)
                       .join(", ") || "not configured"
                   } - Fulfillment providers: ${
                     r.fulfillment_providers
-                      .map(fp => fulfillmentProvidersMapper(fp.id).label)
+                      .map((fp) => fulfillmentProvidersMapper(fp.id).label)
                       .join(", ") || "not configured"
                   }`
                   return (
@@ -92,7 +92,7 @@ const Regions = () => {
                       sublabel={
                         r.countries.length
                           ? `(${r.countries
-                              .map(c => c.display_name)
+                              .map((c) => c.display_name)
                               .join(", ")})`
                           : null
                       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,6 +2574,27 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "^2.4.0"
 
+"@radix-ui/react-popover@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-0.1.4.tgz#f7302ae75f94007edc6294815bc031ec46fa5b4e"
+  integrity sha512-5oaBFkGCGfomXO5HTrhORixDoeAjl3XeSLbVSC9G1Yq//lfaTC5sJYSKSf4mnQulzM9XYchtyjHoBa0O1OBM5Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-dismissable-layer" "0.1.3"
+    "@radix-ui/react-focus-guards" "0.1.0"
+    "@radix-ui/react-focus-scope" "0.1.3"
+    "@radix-ui/react-id" "0.1.4"
+    "@radix-ui/react-popper" "0.1.3"
+    "@radix-ui/react-portal" "0.1.3"
+    "@radix-ui/react-presence" "0.1.1"
+    "@radix-ui/react-primitive" "0.1.3"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "^2.4.0"
+
 "@radix-ui/react-popper@0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-0.1.3.tgz#a93bdd72845566007e5f3868caddd62318bb781e"


### PR DESCRIPTION
**What**

- Adds the ability to force a dropdown menu on Actionables. This is controlled by setting `forceDots` on Actionables (defaults to false). This can also be set on BodyCard by setting `forceDropdown`
- Allows to provide a customTrigger on Actionables (and BodyCard), controlled by setting `customTrigger` to a ReactNode such as `<button onClick={() => console.log("custom")}>Custom Button</button>`. This is controlled on BodyCards by setting `customActionable`.

<img width="565" alt="Skærmbillede 2022-01-28 kl  08 54 59" src="https://user-images.githubusercontent.com/45367945/151509439-1374d313-9744-4771-a2ca-d2d2508300f9.png">
<img width="611" alt="Skærmbillede 2022-01-28 kl  08 55 36" src="https://user-images.githubusercontent.com/45367945/151509499-5ba1909d-a917-4cd0-8cec-02ffe23d0b3c.png">
