### PR TITLE
Fixed: the issue of redirecting to orders page after login(#298)

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -25,7 +25,7 @@ const LoginPage = () => {
         },
         {
           onSuccess: () => {
-            navigate("/a")
+            navigate("/a/orders")
           },
           onError: (err) => {
             setIsInvalidLogin(true)


### PR DESCRIPTION
**What changes are in the PR?**
Changed the redirection logic to go to `/a/orders` after login

**Why these changes are relevant?**
So, after login user will not be redirected to an empty screen

**How have the changes been implemented?**
Added `/orders` onSuccess of login

 **How has the changes been tested or how can the reviewer test the feature?**
 Login to the admin ->  Verify that you are on the orders page and not on an empty page