### PR TITLE
Fix: dropdown overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-json-view": "^1.19.1",
     "react-multi-select-component": "^4.1.15",
     "react-popper": "^2.2.5",
-    "react-select": "^4.1.0",
+    "react-select": "^5.2.2",
     "react-table": "^7.7.0",
     "react-toast-notifications": "^2.4.0",
     "react-tooltip": "^4.2.10",

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -163,54 +163,57 @@
   .radio-outer-ring > span[data-state="checked"] {
     @apply rounded-circle shadow-[#7C3AED] shadow-[0_0_0_2px];
   }
+}
 
-  .multiselect-styling {
-    @apply p-0 -mx-3 mt-1 outline-0 cursor-text;
+@layer components {
+  .react-select-container {
+    @apply p-0 -mx-3 border-0 mb-1 cursor-text h-6;
 
-    .dropdown-container {
-      @apply border-none bg-inherit relative focus-within:shadow-none cursor-text !important;
+    .react-select__control {
+      @apply border-0 bg-inherit shadow-none;
     }
 
-    .dropdown-content {
-      @apply rounded-rounded w-full -mt-3 pt-0 -top-full shadow-input absolute !important;
+    .react-select__control,
+    .react-select__control--is-focused,
+    .react-select__control--menu-is-open {
+      @apply h-6 p-0 m-0 !important;
     }
 
-    .select-item {
-      @apply p-2 my-1 mx-2 rounded bg-grey-0 focus:bg-grey-10 hover:bg-grey-10 flex !important;
+    .react-select__value-container--is-multi,
+    .react-select__value-container--has-value {
+      @apply h-6 pl-3 p-0 m-0 !important;
     }
 
-    .select-panel > div::before {
-      content: url("../../assets/svg-2.0/search.svg");
-      width: 2rem;
-      height: 1.5rem;
-      top: 0;
-      bottom: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+    .react-select__menu,
+    .react-select__menu-list {
+      @apply rounded-t-none mt-0 z-[110] !important;
     }
 
-    .search {
-      @apply py-4 flex items-center px-3 !important;
-    }
-    .search input {
-      @apply h-6 text-grey-90 !important;
-    }
-    .search .search-clear-button {
-      @apply mr-4 !important;
+    .react-select__value-container {
+      @apply pl-3 pr-0;
     }
 
-    .options {
-      @apply mt-1 !important;
+    .react-select__indicators {
+      @apply p-0 h-full items-center flex pr-3;
+
+      .react-select__indicator {
+        @apply p-0;
+      }
     }
 
-    .dropdown-heading-dropdown-arrow,
-    .dropdown-search-clear-icon {
-      @apply hidden;
+    .react-select__input {
+      @apply w-full mt-0 min-w-[120px] pt-0 !important;
     }
 
-    .dropdown-heading {
-      @apply py-0 px-3 outline-0 h-6 cursor-text truncate !important;
+    .react-select__option,
+    .react-select__option--is-focused,
+    .react-select__option--is-selected {
+      @apply bg-grey-0 hover:bg-grey-5 !important;
+    }
+
+    .react-select__multi-value,
+    .react-select__input-container {
+      @apply my-0 py-0;
     }
   }
 }

--- a/src/components/molecules/modal/index.tsx
+++ b/src/components/molecules/modal/index.tsx
@@ -2,7 +2,16 @@ import React from "react"
 import CrossIcon from "../../fundamentals/icons/cross-icon"
 import clsx from "clsx"
 import * as Dialog from "@radix-ui/react-dialog"
+import * as Portal from "@radix-ui/react-portal"
 import { useWindowDimensions } from "../../../hooks/use-window-dimensions"
+
+type ModalState = {
+  portalRef: any
+}
+
+export const ModalContext = React.createContext<ModalState>({
+  portalRef: undefined,
+})
 
 export type ModalProps = {
   isLargeModal?: boolean
@@ -62,13 +71,16 @@ const Modal: ModalType = ({
   isLargeModal = true,
   children,
 }) => {
+  const portalRef = React.useRef(null)
   return (
     <Dialog.Root open={open} onOpenChange={handleClose}>
-      <Dialog.Portal>
-        <Overlay>
-          <Content>{addProp(children, { isLargeModal })}</Content>
-        </Overlay>
-      </Dialog.Portal>
+      <Portal.UnstablePortal ref={portalRef}>
+        <ModalContext.Provider value={{ portalRef }}>
+          <Overlay>
+            <Content>{addProp(children, { isLargeModal })}</Content>
+          </Overlay>
+        </ModalContext.Provider>
+      </Portal.UnstablePortal>
     </Dialog.Root>
   )
 }
@@ -78,7 +90,9 @@ Modal.Body = ({ children, isLargeModal, className, style }) => {
     <div
       style={style}
       className={clsx("inter-base-regular h-full", className)}
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation()
+      }}
     >
       {addProp(children, { isLargeModal })}
     </div>
@@ -124,7 +138,9 @@ Modal.Header = ({ handleClose = undefined, children }) => {
 Modal.Footer = ({ children, isLargeModal }) => {
   return (
     <div
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation()
+      }}
       className={clsx("px-7 bottom-0 pb-5 flex w-full", {
         "border-t border-grey-20 pt-4": isLargeModal,
       })}

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -42,7 +42,6 @@ type MultiSelectProps = {
   hasSelectAll?: boolean
   isLoading?: boolean
   shouldToggleOnHover?: boolean
-  overrideStrings?: object
   onChange: (values: any[] | any) => void
   disabled?: boolean
   enableSearch?: boolean
@@ -196,7 +195,6 @@ const SSelect = React.forwardRef(
       isMultiSelect,
       hasSelectAll,
       enableSearch = false,
-      overrideStrings,
       clearSelected = false,
       isCreatable,
       filterOptions,

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -242,54 +242,6 @@ const SSelect = React.forwardRef(
       }
     }
 
-    const select = (
-      <GetSelect
-        isCreatable={isCreatable}
-        searchBackend={filterOptions}
-        options={
-          hasSelectAll && isMultiSelect
-            ? [{ value: "all", label: "Select All" }, ...options]
-            : options
-        }
-        handleClose={() => setIsOpen(false)}
-        ref={selectRef}
-        value={value}
-        isMulti={isMultiSelect}
-        openMenuOnFocus={true}
-        isSearchable={enableSearch}
-        menuIsOpen={isOpen}
-        isClearable={clearSelected}
-        onChange={onClickOption}
-        closeMenuOnScroll={(e) => {
-          if (isOpen && e.target?.contains(containerRef.current)) {
-            setIsOpen(!isOpen)
-          }
-        }}
-        closeMenuOnSelect={!isMultiSelect}
-        styles={{ menuPortal: (base) => ({ ...base, zIndex: 60 }) }}
-        hideSelectedOptions={false}
-        menuPortalTarget={portalRef?.current?.lastChild || document.body}
-        menuPlacement="auto"
-        backspaceRemovesValue={false}
-        classNamePrefix="react-select"
-        placeholder={placeholder}
-        className="react-select-container"
-        onCreateOption={handleOnCreateOption}
-        components={{
-          DropdownIndicator: () => null,
-          IndicatorSeparator: () => null,
-          MultiValueRemove: () => null,
-          Placeholder,
-          MultiValueLabel,
-          Option,
-          Input,
-          Menu,
-          SingleValue,
-          ClearIndicator: ClearIndicatorFunc(setIsOpen),
-        }}
-      />
-    )
-
     return (
       <div ref={containerRef}>
         <InputContainer
@@ -312,7 +264,55 @@ const SSelect = React.forwardRef(
               prepend: true,
             })}
           >
-            {select}
+            {
+              <GetSelect
+                isCreatable={isCreatable}
+                searchBackend={filterOptions}
+                options={
+                  hasSelectAll && isMultiSelect
+                    ? [{ value: "all", label: "Select All" }, ...options]
+                    : options
+                }
+                handleClose={() => setIsOpen(false)}
+                ref={selectRef}
+                value={value}
+                isMulti={isMultiSelect}
+                openMenuOnFocus={true}
+                isSearchable={enableSearch}
+                menuIsOpen={isOpen}
+                isClearable={clearSelected}
+                onChange={onClickOption}
+                closeMenuOnScroll={(e) => {
+                  if (isOpen && e.target?.contains(containerRef.current)) {
+                    setIsOpen(!isOpen)
+                  }
+                }}
+                closeMenuOnSelect={!isMultiSelect}
+                styles={{ menuPortal: (base) => ({ ...base, zIndex: 60 }) }}
+                hideSelectedOptions={false}
+                menuPortalTarget={
+                  portalRef?.current?.lastChild || document.body
+                }
+                menuPlacement="auto"
+                backspaceRemovesValue={false}
+                classNamePrefix="react-select"
+                placeholder={placeholder}
+                className="react-select-container"
+                onCreateOption={handleOnCreateOption}
+                components={{
+                  DropdownIndicator: () => null,
+                  IndicatorSeparator: () => null,
+                  MultiValueRemove: () => null,
+                  Placeholder,
+                  MultiValueLabel,
+                  Option,
+                  Input,
+                  Menu,
+                  SingleValue,
+                  ClearIndicator: ClearIndicatorFunc(setIsOpen),
+                }}
+              />
+            }
           </CacheProvider>
           {isOpen && enableSearch && <div className="w-full h-5" />}
         </InputContainer>

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, useContext, useRef, useState } from "react"
+import React, { useContext, useRef, useState } from "react"
 import Select, {
   ClearIndicatorProps,
   components,
@@ -18,17 +18,6 @@ import SearchIcon from "../../fundamentals/icons/search-icon"
 import { CacheProvider } from "@emotion/react"
 import createCache from "@emotion/cache"
 import { ModalContext } from "../modal"
-
-type OptionType = React.OptionHTMLAttributes<HTMLOptionElement> & {
-  key?: string
-}
-
-type ItemRendererProps = {
-  checked?: boolean
-  onClick?: ChangeEventHandler<HTMLElement>
-  disabled?: boolean
-  option?: OptionType
-}
 
 type MultiSelectProps = {
   // component props
@@ -56,42 +45,6 @@ type MultiSelectProps = {
   clearSelected?: boolean
   onCreateOption?: (value: string) => { value: string; label: string }
 }
-
-// const valueRenderer = (selected, _options) => {
-//   return selected.length && selected[0]
-//     ? selected.map(({ label }) => label).join(", ")
-//     : undefined
-// }
-
-// const ItemRenderer: React.FC<ItemRendererProps> = ({
-//   checked,
-//   option,
-//   onClick,
-//   disabled,
-// }) => (
-//   <div className={`item-renderer ${disabled && "disabled"} w-full h-full`}>
-//     <div className="items-center h-full flex">
-//       <div
-//         className={`w-5 h-5 flex justify-center text-grey-0 border-grey-30 border rounded-base ${
-//           checked && "bg-violet-60"
-//         }`}
-//       >
-//         <span className="self-center">
-//           {checked && <CheckIcon size={16} />}
-//         </span>
-//       </div>
-//       <input
-//         className="hidden"
-//         type="checkbox"
-//         onChange={onClick}
-//         checked={checked}
-//         tabIndex={-1}
-//         disabled={disabled}
-//       />
-//       <span className="ml-3 text-grey-90">{option.label}</span>
-//     </div>
-//   </div>
-// )
 
 const MultiValueLabel = ({ ...props }: MultiValueProps) => {
   const isLast =
@@ -285,32 +238,6 @@ const SSelect = React.forwardRef(
           />
         </CacheProvider>
         {isOpen && enableSearch && <div className="w-full h-5" />}
-        {/* <MultiSelect
-          labelledBy={labelledBy}
-          value={isMultiSelect ? value : value ? [value] : []}
-          isOpen={isOpen}
-          hasSelectAll={hasSelectAll}
-          ItemRenderer={ItemRenderer}
-          className="multiselect-styling"
-          overrideStrings={{
-            search: "Search...",
-            ...overrideStrings,
-          }}
-          ClearIcon={
-            <span className="text-grey-40">
-              <XCircleIcon size={20} />
-            </span>
-          }
-          onChange={handleSelect}
-          valueRenderer={valueRenderer}
-          {...selectOptions}
-          disableSearch={!enableSearch}
-          ClearSelectedIcon={
-            <span className="text-grey-40">
-              {clearSelected && <XCircleIcon size={20} />}
-            </span>
-          }
-        /> */}
       </InputContainer>
     )
   }

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -147,7 +147,7 @@ const ClearIndicatorFunc = (setIsOpen) => ({
 }
 
 const Option = ({ className, ...props }: OptionProps) => {
-  // is selected for single select: state.data === state.selectProps.value
+  console.log(props)
   return (
     <components.Option
       {...props}
@@ -157,18 +157,26 @@ const Option = ({ className, ...props }: OptionProps) => {
         className={`item-renderer h-full hover:bg-grey-10 py-2 px-2 cursor-pointer rounded`}
       >
         <div className="items-center h-full flex">
-          <div
-            className={`w-5 h-5 flex justify-center text-grey-0 border-grey-30 border rounded-base ${
-              props.isSelected && "bg-violet-60"
-            }`}
-          >
-            <span className="self-center">
-              {props.isSelected && <CheckIcon size={16} />}
+          {props.data?.value !== "all" && props.data?.label !== "Select All" ? (
+            <>
+              <div
+                className={`w-5 h-5 flex justify-center text-grey-0 border-grey-30 border rounded-base ${
+                  props.isSelected && "bg-violet-60"
+                }`}
+              >
+                <span className="self-center">
+                  {props.isSelected && <CheckIcon size={16} />}
+                </span>
+              </div>
+              <span className="ml-3 text-grey-90 inter-base-regular">
+                {props.data.label}
+              </span>
+            </>
+          ) : (
+            <span className="text-grey-90 inter-base-regular">
+              {props.data.label}
             </span>
-          </div>
-          <span className="ml-3 text-grey-90 inter-base-regular">
-            {props.data.label}
-          </span>
+          )}
         </div>
       </div>
     </components.Option>
@@ -212,9 +220,18 @@ const SSelect = React.forwardRef(
     }
 
     const onClickOption = (val) => {
-      onChange(val)
-      if (!isMultiSelect) {
-        setIsOpen(false)
+      if (
+        val.length &&
+        val.find((option) => option.value === "all") &&
+        hasSelectAll &&
+        isMultiSelect
+      ) {
+        onChange(options)
+      } else {
+        onChange(val)
+        if (!isMultiSelect) {
+          setIsOpen(false)
+        }
       }
     }
 
@@ -249,7 +266,11 @@ const SSelect = React.forwardRef(
           <GetSelect
             isCreatable={isCreatable}
             searchBackend={filterOptions}
-            options={options}
+            options={
+              hasSelectAll && isMultiSelect
+                ? [{ value: "all", label: "Select All" }, ...options]
+                : options
+            }
             handleClose={() => setIsOpen(false)}
             ref={selectRef}
             value={value}

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -38,6 +38,7 @@ type MultiSelectProps = {
     | { label: string; value: string }[]
     | { label: string; value: string }
     | null
+  filterOptions?: (q: string) => any[]
   hasSelectAll?: boolean
   isLoading?: boolean
   shouldToggleOnHover?: boolean
@@ -87,7 +88,6 @@ const Placeholder = (props: PlaceholderProps) => {
 }
 
 const SingleValue = ({ children, ...props }: SingleValueProps) => {
-  console.log(props)
   if (props.selectProps.menuIsOpen && props.selectProps.isSearchable) {
     return null
   }
@@ -182,7 +182,6 @@ const SSelect = React.forwardRef(
       labelledBy = "label",
       options,
       onCreateOption,
-      ...selectOptions
     }: MultiSelectProps,
     ref
   ) => {

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -181,6 +181,7 @@ const SSelect = React.forwardRef(
       placeholder = "Search...",
       labelledBy = "label",
       options,
+      onCreateOption,
       ...selectOptions
     }: MultiSelectProps,
     ref
@@ -201,6 +202,13 @@ const SSelect = React.forwardRef(
     const onClickOption = (val) => {
       onChange(val)
       if (!isMultiSelect) {
+        setIsOpen(false)
+      }
+    }
+
+    const handleOnCreateOption = (val) => {
+      if (onCreateOption) {
+        onCreateOption(val)
         setIsOpen(false)
       }
     }
@@ -247,7 +255,7 @@ const SSelect = React.forwardRef(
             classNamePrefix="react-select"
             placeholder={placeholder}
             className="react-select-container"
-            onCreateOption={selectOptions.onCreateOption}
+            onCreateOption={handleOnCreateOption}
             components={{
               DropdownIndicator: () => null,
               IndicatorSeparator: () => null,
@@ -272,40 +280,39 @@ const GetSelect = ({
   isCreatable,
   searchBackend,
   onCreateOption,
-  onChange,
   handleClose,
   ...props
 }) => {
-  const onChangeCreate = (newVal, meta) => {
-    if (meta.action === "create-option") {
-      onCreateOption(newVal)
-    } else {
-      onChange(newVal)
-    }
-  }
+  // const onChangeCreate = (newVal, meta) => {
+  //   if (meta.action === "create-option") {
+  //     onCreateOption(newVal)
+  //   } else {
+  //     onChange(newVal)
+  //   }
+  // }
 
   if (isCreatable) {
     return searchBackend ? (
       <AsyncCreatableSelect
         defaultOptions={true}
-        onChange={onChangeCreate}
+        // onChange={onChangeCreate}
+        onCreateOption={onCreateOption}
         loadOptions={searchBackend}
         {...props}
       />
     ) : (
-      <CreatableSelect {...props} onChange={onChangeCreate} />
+      <CreatableSelect {...props} onCreateOption={onCreateOption} />
     )
   } else if (searchBackend) {
     return (
       <AsyncSelect
-        onChange={onChange}
         defaultOptions={true}
         loadOptions={searchBackend}
         {...props}
       />
     )
   }
-  return <Select {...props} onChange={onChange} />
+  return <Select {...props} />
 }
 
 export default SSelect

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -121,13 +121,26 @@ const Input = (props: InputProps) => {
   )
 }
 
-const ClearIndicator = ({ ...props }: ClearIndicatorProps) => {
+const ClearIndicatorFunc = (setIsOpen) => ({
+  ...props
+}: ClearIndicatorProps) => {
   if (props.selectProps.menuIsOpen && props.selectProps.isMulti) {
     return <></>
   }
 
+  const {
+    innerProps: { ref, ...restInnerProps },
+  } = props
+
   return (
-    <div className="hover:bg-grey-10 text-grey-40 rounded cursor-pointer">
+    <div
+      onMouseDown={(e) => {
+        setIsOpen(true)
+        restInnerProps.onMouseDown(e)
+      }}
+      ref={ref}
+      className="hover:bg-grey-10 text-grey-40 rounded cursor-pointer"
+    >
       <XCircleIcon size={20} />
     </div>
   )
@@ -175,7 +188,7 @@ const SSelect = React.forwardRef(
       hasSelectAll,
       enableSearch = false,
       overrideStrings,
-      clearSelected,
+      clearSelected = false,
       isCreatable,
       filterOptions,
       placeholder = "Search...",
@@ -262,10 +275,10 @@ const SSelect = React.forwardRef(
               Placeholder,
               MultiValueLabel,
               Option,
-              ClearIndicator,
               Input,
               Menu,
               SingleValue,
+              ClearIndicator: ClearIndicatorFunc(setIsOpen),
             }}
           />
         </CacheProvider>

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -73,7 +73,9 @@ const MultiValueLabel = ({ ...props }: MultiValueProps) => {
 const Menu = ({ className, ...props }: MenuProps) => {
   return (
     <components.Menu
-      className={clsx({ "-mt-1 z-60": !props.selectProps.isSearchable })}
+      className={clsx({
+        "-mt-1 z-60": !props.selectProps.isSearchable,
+      })}
       {...props}
     >
       {props.children}
@@ -199,7 +201,6 @@ const SSelect = React.forwardRef(
       isCreatable,
       filterOptions,
       placeholder = "Search...",
-      labelledBy = "label",
       options,
       onCreateOption,
     }: MultiSelectProps,
@@ -282,8 +283,14 @@ const SSelect = React.forwardRef(
                 menuIsOpen={isOpen}
                 isClearable={clearSelected}
                 onChange={onClickOption}
+                menuShouldScrollIntoView={false}
                 closeMenuOnScroll={(e) => {
-                  if (isOpen && e.target?.contains(containerRef.current)) {
+                  e.stopImmediatePropagation()
+                  if (
+                    isOpen &&
+                    e.target?.contains(containerRef.current) &&
+                    e.target !== document
+                  ) {
                     setIsOpen(!isOpen)
                   }
                 }}

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -282,14 +282,6 @@ const GetSelect = ({
   handleClose,
   ...props
 }) => {
-  // const onChangeCreate = (newVal, meta) => {
-  //   if (meta.action === "create-option") {
-  //     onCreateOption(newVal)
-  //   } else {
-  //     onChange(newVal)
-  //   }
-  // }
-
   if (isCreatable) {
     return searchBackend ? (
       <AsyncCreatableSelect

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -210,6 +210,7 @@ const SSelect = React.forwardRef(
     const [isOpen, setIsOpen] = useState(false)
 
     let selectRef = useRef(null)
+    let containerRef = useRef(null)
 
     const onClick = () => {
       if (!isOpen) {
@@ -260,7 +261,7 @@ const SSelect = React.forwardRef(
         isClearable={clearSelected}
         onChange={onClickOption}
         closeMenuOnScroll={(e) => {
-          if (isOpen) {
+          if (isOpen && e.target?.contains(containerRef.current)) {
             setIsOpen(!isOpen)
           }
         }}
@@ -290,30 +291,32 @@ const SSelect = React.forwardRef(
     )
 
     return (
-      <InputContainer
-        key={name}
-        onFocusLost={() => setIsOpen(false)}
-        onClick={onClick}
-        className={clsx(className, { "bg-white rounded-t-rounded": isOpen })}
-      >
-        {isOpen && enableSearch ? (
-          <></>
-        ) : (
-          <div className="w-full flex text-grey-50 pr-0.5 justify-between pointer-events-none cursor-pointer">
-            <InputHeader {...{ label, required }} />
-            <ArrowDownIcon size={16} />
-          </div>
-        )}
-        <CacheProvider
-          value={createCache({
-            key: "my-select-cache",
-            prepend: true,
-          })}
+      <div ref={containerRef}>
+        <InputContainer
+          key={name}
+          onFocusLost={() => setIsOpen(false)}
+          onClick={onClick}
+          className={clsx(className, { "bg-white rounded-t-rounded": isOpen })}
         >
-          {select}
-        </CacheProvider>
-        {isOpen && enableSearch && <div className="w-full h-5" />}
-      </InputContainer>
+          {isOpen && enableSearch ? (
+            <></>
+          ) : (
+            <div className="w-full flex text-grey-50 pr-0.5 justify-between pointer-events-none cursor-pointer">
+              <InputHeader {...{ label, required }} />
+              <ArrowDownIcon size={16} />
+            </div>
+          )}
+          <CacheProvider
+            value={createCache({
+              key: "my-select-cache",
+              prepend: true,
+            })}
+          >
+            {select}
+          </CacheProvider>
+          {isOpen && enableSearch && <div className="w-full h-5" />}
+        </InputContainer>
+      </div>
     )
   }
 )

--- a/src/domain/orders/details/claim/create.tsx
+++ b/src/domain/orders/details/claim/create.tsx
@@ -327,7 +327,7 @@ const ClaimMenu = ({ order, onCreate, onDismiss, toaster }) => {
                 clearSelected
                 label="Shipping Method"
                 className="mt-2"
-                overrideStrings={{ search: "Add a shipping method" }}
+                placeholder="Add a shipping method"
                 value={
                   returnShippingMethod
                     ? {
@@ -531,7 +531,7 @@ const ClaimMenu = ({ order, onCreate, onDismiss, toaster }) => {
                 <Select
                   label="Shipping Method"
                   className="mt-2"
-                  overrideStrings={{ search: "Add a shipping method" }}
+                  placeholder="Add a shipping method"
                   value={
                     shippingMethod
                       ? {

--- a/src/domain/orders/details/returns/index.tsx
+++ b/src/domain/orders/details/returns/index.tsx
@@ -73,7 +73,7 @@ const ReturnMenu = ({ order, onDismiss, toaster }) => {
     const items = Object.entries(toReturn).map(([key, value]) => {
       const toSet = {
         reason_id: value.reason?.value.id,
-        ...value
+        ...value,
       }
       delete toSet.reason
       const clean = removeNullish(toSet)
@@ -165,7 +165,7 @@ const ReturnMenu = ({ order, onDismiss, toaster }) => {
               <Select
                 label="Shipping Method"
                 className="mt-2"
-                overrideStrings={{ search: "Add a shipping method" }}
+                placeholder="Add a shipping method"
                 value={shippingMethod}
                 onChange={handleShippingSelected}
                 options={shippingOptions.map((o) => ({

--- a/src/domain/orders/details/swap/create.tsx
+++ b/src/domain/orders/details/swap/create.tsx
@@ -213,7 +213,7 @@ const SwapMenu = ({ order, onCreate, onDismiss, toaster }) => {
               <Select
                 label="Shipping Method"
                 className="mt-2"
-                overrideStrings={{ search: "Add a shipping method" }}
+                placeholder="Add a shipping method"
                 value={shippingMethod}
                 onChange={handleShippingSelected}
                 options={shippingOptions.map((o) => ({

--- a/src/domain/orders/new/components/shipping-details.tsx
+++ b/src/domain/orders/new/components/shipping-details.tsx
@@ -104,6 +104,7 @@ const ShippingDetails = ({
   }
 
   const onCustomerCreate = (val) => {
+    console.log(val)
     setCustomerAddresses([])
     setAddNew(true)
     form.setValue("email", val)

--- a/src/domain/orders/new/components/shipping-details.tsx
+++ b/src/domain/orders/new/components/shipping-details.tsx
@@ -67,7 +67,6 @@ const ShippingDetails = ({
   }
 
   const onCustomerSelect = async (val) => {
-    console.log(val)
     const email = /\(([^()]*)\)$/.exec(val?.label)
 
     if (!val || !email) {
@@ -104,7 +103,6 @@ const ShippingDetails = ({
   }
 
   const onCustomerCreate = (val) => {
-    console.log(val)
     setCustomerAddresses([])
     setAddNew(true)
     form.setValue("email", val)

--- a/src/domain/orders/new/components/shipping-details.tsx
+++ b/src/domain/orders/new/components/shipping-details.tsx
@@ -45,7 +45,7 @@ const ShippingDetails = ({
   }, [shipping])
 
   // "region",
-  const debouncedFetch = (options, filter) => {
+  const debouncedFetch = (filter) => {
     const prepared = qs.stringify(
       {
         q: filter,
@@ -67,6 +67,7 @@ const ShippingDetails = ({
   }
 
   const onCustomerSelect = async (val) => {
+    console.log(val)
     const email = /\(([^()]*)\)$/.exec(val?.label)
 
     if (!val || !email) {


### PR DESCRIPTION
**What** 
- fix overflow issue with dropdown

**How** 
- switch dropdown component from `react-multi-select-component` to `react-select` (which has more users, stars and downloads in general)
- `react-select` supports native portalling of the dropdown which enables us to show it as an overlay instead, which `react-multi-select-component` doesn't have
- add `ModalContext` which exposes a ref to the modal portal
