### PR TITLE
fix visual bug in sidebar team member

### DIFF
--- a/src/components/molecules/sidebar-team-member/index.tsx
+++ b/src/components/molecules/sidebar-team-member/index.tsx
@@ -16,7 +16,7 @@ const SidebarTeamMember: React.FC<SidebarTeamMemberProps> = ({
       : user.email
 
   return (
-    <div className="flex items-center bg-grey-0 px-2.5 py-1.5 w-full">
+    <div className="flex items-center bg-inherit px-2.5 py-1.5 w-full">
       <div className="w-[24px] h-[24px]">
         <Avatar user={user} color={color} />
       </div>


### PR DESCRIPTION
**What** 
- add `bg-inherit` to sidebar team member to prevent visual bug in tables and with other hover effects(bg was previously `bg-grey-0` causing no changes when a table row was hovered):

![image](https://user-images.githubusercontent.com/88927411/153925279-ca6964a9-8fc7-42eb-989e-58e53b5fd44f.png)
