### PR TITLE
Fix: Tag input blur case

### DIFF
--- a/src/components/molecules/tag-input/index.tsx
+++ b/src/components/molecules/tag-input/index.tsx
@@ -132,7 +132,12 @@ const TagInput: React.FC<TagInputProps> = ({
   }
 
   const handleBlur = (e) => {
+    const value = inputRef?.current?.value
     setHighlighted(-1)
+
+    if (value) {
+      handleAddValue(value)
+    }
   }
 
   const handleOnContainerFocus = () => {


### PR DESCRIPTION
**What**

Fix of the tag input `onBlur` behavior.

**Why**

If the user hasn't added a comma as the last input character the last tag would not register.

**How**

Updated the `handleBlur` method to also call the `handleAddValue`.
