### PR TITLE
fix: enable separate email updates for order overview

### DIFF
--- a/src/domain/orders/details/address-modal.tsx
+++ b/src/domain/orders/details/address-modal.tsx
@@ -1,3 +1,4 @@
+import { Country } from "@medusajs/medusa"
 import React, { useState } from "react"
 import { useForm } from "react-hook-form"
 import Button from "../../../components/fundamentals/button"
@@ -8,22 +9,20 @@ import Select from "../../../components/molecules/select"
 type AddressModalProps = {
   handleClose: () => void
   handleSave: ({ data, type }) => Promise<void>
-  allowedCountries: string[]
-  address?: object
-  email?: string
+  allowedCountries?: Country[]
+  address?: object & { country_code: string }
   type: "shipping" | "billing"
 }
 
 const AddressModal: React.FC<AddressModalProps> = ({
   address,
-  email,
   allowedCountries = [],
   handleClose,
   handleSave,
   type,
 }) => {
   const { register, handleSubmit, setValue } = useForm({
-    defaultValues: { ...address, email },
+    defaultValues: { ...address },
   })
 
   register("country_code")
@@ -46,8 +45,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
   }
 
   const submit = (data) => {
-    // Note: Data will contain email as well, which is not a part of addresses
-    // Therefore, you will need to handle this in parent handleSave method
     return handleSave({ data, type })
   }
 
@@ -77,12 +74,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
               />
             </div>
             <div className="flex mt-4 space-x-4">
-              <Input
-                label="Email"
-                name="email"
-                ref={register}
-                placeholder="Email"
-              />
               <Input
                 label="Phone"
                 name="phone"

--- a/src/domain/orders/details/email-modal.tsx
+++ b/src/domain/orders/details/email-modal.tsx
@@ -1,0 +1,70 @@
+import React from "react"
+import { useForm } from "react-hook-form"
+
+import Button from "../../../components/fundamentals/button"
+import Input from "../../../components/molecules/input"
+import Modal from "../../../components/molecules/modal"
+
+type EmailModalProps = {
+  handleClose: () => void
+  handleSave: ({ email: string }) => Promise<void>
+  email?: string
+}
+
+const EmailModal: React.FC<EmailModalProps> = ({
+  email,
+  handleClose,
+  handleSave,
+}) => {
+  const { register, handleSubmit } = useForm({
+    defaultValues: { email },
+  })
+
+  const submit = (data) => {
+    return handleSave(data)
+  }
+
+  return (
+    <Modal handleClose={handleClose}>
+      <Modal.Body>
+        <Modal.Header handleClose={handleClose}>
+          <span className="inter-xlarge-semibold">Email Address</span>
+        </Modal.Header>
+        <Modal.Content>
+          <div className="space-y-4">
+            <div className="flex mt-4 space-x-4">
+              <Input
+                label="Email"
+                name="email"
+                ref={register}
+                placeholder="Email"
+              />
+            </div>
+          </div>
+        </Modal.Content>
+        <Modal.Footer>
+          <div className="flex w-full h-8 justify-end">
+            <Button
+              variant="ghost"
+              className="mr-2 w-32 text-small justify-center"
+              size="large"
+              onClick={handleClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="large"
+              className="w-32 text-small justify-center"
+              variant="primary"
+              onClick={handleSubmit(submit)}
+            >
+              Save
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal.Body>
+    </Modal>
+  )
+}
+
+export default EmailModal


### PR DESCRIPTION
**What**

 - Added a dropdown option that allows the email edit
 - Added the email modal

**Why**

 - Changes enable a merchant to edit the email on an order separately from the "Edit shipping/billing address" modal
