### PR TITLE
fix: broken gradient on safari

### DIFF
--- a/src/components/organisms/body-card.tsx
+++ b/src/components/organisms/body-card.tsx
@@ -42,7 +42,7 @@ const BodyCard: React.FC<BodyCardProps> = ({
       {...rest}
     >
       {isScrolled && (
-        <div className="absolute top-0 left-0 right-0 bg-gradient-to-b from-grey-0 to-transparent h-xlarge z-10" />
+        <div className="absolute rounded-t-rounded top-0 left-0 right-0 bg-gradient-to-b from-grey-0 to-[rgba(255,255,255,0)] h-xlarge z-10" />
       )}
       <div
         className="pt-medium px-xlarge flex flex-col grow overflow-y-auto"


### PR DESCRIPTION
Closes #352.

Fixes a bug that renders the "fading" gradient effect in the body card in a weird way on Safari.

Apparently, [Safari treats `transparent` differently](https://stackoverflow.com/questions/38391457/linear-gradient-to-transparent-bug-in-latest-safari#:~:text=For%20most%20browsers,along%20the%20gradient.) than other browsers so that gradients that use the `transparent` keyword look weird. 

Also added `rounded-t-rounded` to the overlay so that the corners don't overflow the body card.