### PR TITLE
fix: change registry used to install react-select

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14853,7 +14853,7 @@ react-router@6.2.1, react-router@^6.0.0:
 
 react-select@^5.2.2:
   version "5.2.2"
-  resolved "http://localhost:4873/react-select/-/react-select-5.2.2.tgz#3d5edf0a60f1276fd5f29f9f90a305f0a25a5189"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.2.tgz#3d5edf0a60f1276fd5f29f9f90a305f0a25a5189"
   integrity sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==
   dependencies:
     "@babel/runtime" "^7.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4211,7 +4211,7 @@
 
 "@types/react-transition-group@^4.4.0":
   version "4.4.4"
-  resolved "http://localhost:4873/@types%2freact-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
+  resolved "https://registry.yarnpkg.com/@types%2freact-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
   integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
   dependencies:
     "@types/react" "*"


### PR DESCRIPTION
Noticed that the jobs we have in our pipeline are failing in a lot of open PRs. This fixes it by updating the registry that should be used for installing `react-select`