### PR TITLE
fix: currency input width

### DIFF
--- a/src/components/organisms/currency-input/index.tsx
+++ b/src/components/organisms/currency-input/index.tsx
@@ -115,7 +115,7 @@ const CurrencyInput: React.FC<CurrencyInputProps> & {
           className={clsx(
             { "basis-[140px] max-w-[144px]": size === "medium" },
             { "basis-[120px] max-w-[120px]": size === "small" },
-            { "basis-full max-w-full": size === "full" }
+            { "flex-1": size === "full" }
           )}
         >
           {!readOnly ? (

--- a/src/domain/settings/regions/new-shipping.tsx
+++ b/src/domain/settings/regions/new-shipping.tsx
@@ -180,7 +180,11 @@ const NewShipping = ({
                 placeholder="New Shipping Option"
                 className="flex-grow"
               />
-              <CurrencyInput currentCurrency={region.currency_code} readOnly>
+              <CurrencyInput
+                currentCurrency={region.currency_code}
+                readOnly
+                size="small"
+              >
                 <CurrencyInput.AmountInput
                   label="Price"
                   onChange={(v) => handleAmountChange("amount", v)}
@@ -239,6 +243,7 @@ const NewShipping = ({
                   <CurrencyInput
                     currentCurrency={region.currency_code}
                     readOnly
+                    size="medium"
                   >
                     <CurrencyInput.AmountInput
                       label="Price"
@@ -254,6 +259,7 @@ const NewShipping = ({
                   <CurrencyInput
                     currentCurrency={region.currency_code}
                     readOnly
+                    size="medium"
                   >
                     <CurrencyInput.AmountInput
                       label="Price"

--- a/src/domain/settings/regions/new-shipping.tsx
+++ b/src/domain/settings/regions/new-shipping.tsx
@@ -243,7 +243,7 @@ const NewShipping = ({
                   <CurrencyInput
                     currentCurrency={region.currency_code}
                     readOnly
-                    size="medium"
+                    size="small"
                   >
                     <CurrencyInput.AmountInput
                       label="Price"
@@ -259,7 +259,7 @@ const NewShipping = ({
                   <CurrencyInput
                     currentCurrency={region.currency_code}
                     readOnly
-                    size="medium"
+                    size="small"
                   >
                     <CurrencyInput.AmountInput
                       label="Price"


### PR DESCRIPTION
### What

- fixes currency input styling when `size="full"`

### How

- instead of doing `basis-full` we can just use `flex-1` instead. This allows the currency input to take the full width of the container in case the currency input does not have children, otherwise container width will be split equally between both children 
