### PR TITLE
fix: free shipping discount

### DIFF
--- a/src/components/templates/discount-general/index.tsx
+++ b/src/components/templates/discount-general/index.tsx
@@ -90,7 +90,7 @@ const DiscountGeneral: React.FC<DiscountGeneralProps> = ({
           <StatusSelector
             isDraft={isDisabled}
             activeState="Active"
-            draftState="Draft"
+            draftState="Disable"
             onChange={() => {
               if (onStatusChange) {
                 onStatusChange()

--- a/src/components/templates/discount-table/use-discount-columns.tsx
+++ b/src/components/templates/discount-table/use-discount-columns.tsx
@@ -22,7 +22,7 @@ const getDiscountStatus = (discount) => {
       return <StatusDot title="Active" variant="success" />
     }
   }
-  return <StatusDot title="Draft" variant="default" />
+  return <StatusDot title="Disabled" variant="default" />
 }
 
 const getCurrencySymbol = (discount) => {

--- a/src/domain/discounts/new/index.tsx
+++ b/src/domain/discounts/new/index.tsx
@@ -1,3 +1,4 @@
+import { Discount } from "@medusajs/medusa"
 import { RouteComponentProps } from "@reach/router"
 import { navigate, PageProps } from "gatsby"
 import {
@@ -21,7 +22,10 @@ import { hydrateDiscount } from "../../../utils/hydrate-discount"
 import { getNativeSymbol, persistedPrice } from "../../../utils/prices"
 import { DiscountFormType } from "../types"
 
-type NewProps = RouteComponentProps & PageProps
+type NewProps = RouteComponentProps<{
+  location: { state: { discount?: Discount } }
+}> &
+  PageProps
 
 const New: React.FC<NewProps> = ({ location }) => {
   const { regions } = useAdminRegions()
@@ -112,7 +116,7 @@ const New: React.FC<NewProps> = ({ location }) => {
           : discountType === "fixed"
           ? getPersistedPrice(parseFloat(data.rule.value))
           : parseFloat(data.rule.value),
-        type: discountType,
+        type: isFreeShipping ? "free_shipping" : discountType,
         allocation: allocationItem ? "item" : "total",
         valid_for: appliesToAll
           ? undefined


### PR DESCRIPTION
**What**
- Makes it possible to create a `free_shipping` discount.
- Also fixes `location.state` type on `discounts/new`
- also changes "draft" button to "disable"