### PR TITLE
fix: replace the endpoint for fetching customers of a group

### DIFF
--- a/src/domain/customers/groups/customer-group-modal.tsx
+++ b/src/domain/customers/groups/customer-group-modal.tsx
@@ -36,7 +36,16 @@ function CustomerGroupModal(props: CustomerGroupModalProps) {
 
   const onSubmit = (data) => {
     const meta = {}
+    const initial = props.initialData?.metadata || {}
+
     metadata.forEach((m) => (meta[m.key] = m.value))
+
+    for (const m in initial) {
+      if (!(m in meta)) {
+        meta[m] = null
+      }
+    }
+
     data.metadata = meta
 
     handleSubmit(data)

--- a/src/domain/customers/groups/details.tsx
+++ b/src/domain/customers/groups/details.tsx
@@ -7,6 +7,7 @@ import {
   useAdminCustomerGroup,
   useAdminCustomerGroupCustomers,
   useAdminCustomerGroups,
+  useAdminCustomers,
   useAdminDeleteCustomerGroup,
   useAdminRemoveCustomersFromCustomerGroup,
 } from "medusa-react"
@@ -63,14 +64,10 @@ function CustomerGroupCustomersList(props: CustomerGroupCustomersListProps) {
     defaultQueryProps
   )
 
-  // TODO revisit: current logic in the API layer will return customers for `activeGroupId` but also for the `groupId`
-  const { customers = [], isLoading, count } = useAdminCustomerGroupCustomers(
-    groupId,
-    {
-      ...queryObject,
-      groups: activeGroupId ? [activeGroupId] : null,
-    }
-  )
+  const { customers = [], isLoading, count } = useAdminCustomers({
+    ...queryObject,
+    groups: activeGroupId ? [groupId, activeGroupId] : [groupId],
+  })
 
   const { mutate: addCustomers } = useAdminAddCustomersToCustomerGroup(groupId)
   const { mutate: removeCustomers } = useAdminRemoveCustomersFromCustomerGroup(
@@ -78,8 +75,6 @@ function CustomerGroupCustomersList(props: CustomerGroupCustomersListProps) {
   )
 
   const { customer_groups } = useAdminCustomerGroups({ expand: "customers" })
-
-  // useSetSearchParams(representationObject)
 
   const filteringOptions = [
     {

--- a/src/domain/customers/groups/details.tsx
+++ b/src/domain/customers/groups/details.tsx
@@ -6,8 +6,6 @@ import {
   useAdminAddCustomersToCustomerGroup,
   useAdminCustomerGroup,
   useAdminCustomerGroupCustomers,
-  useAdminCustomerGroups,
-  useAdminCustomers,
   useAdminDeleteCustomerGroup,
   useAdminRemoveCustomersFromCustomerGroup,
 } from "medusa-react"
@@ -55,8 +53,6 @@ type CustomerGroupCustomersListProps = { group: CustomerGroup }
 function CustomerGroupCustomersList(props: CustomerGroupCustomersListProps) {
   const groupId = props.group.id
 
-  // an id of a group that is currently active in the table filters
-  const [activeGroupId, setActiveGroupId] = useState()
   // toggle to show/hide "edit customers" modal
   const [showCustomersModal, setShowCustomersModal] = useState(false)
 
@@ -64,34 +60,15 @@ function CustomerGroupCustomersList(props: CustomerGroupCustomersListProps) {
     defaultQueryProps
   )
 
-  const { customers = [], isLoading, count } = useAdminCustomers({
-    ...queryObject,
-    groups: activeGroupId ? [groupId, activeGroupId] : [groupId],
-  })
+  const { customers = [], isLoading, count } = useAdminCustomerGroupCustomers(
+    groupId,
+    queryObject
+  )
 
   const { mutate: addCustomers } = useAdminAddCustomersToCustomerGroup(groupId)
   const { mutate: removeCustomers } = useAdminRemoveCustomersFromCustomerGroup(
     groupId
   )
-
-  const { customer_groups } = useAdminCustomerGroups({ expand: "customers" })
-
-  const filteringOptions = [
-    {
-      title: "Groups",
-      options: [
-        {
-          title: "All",
-          onClick: () => setActiveGroupId(null),
-        },
-        ...(customer_groups || []).map((g) => ({
-          title: g.name,
-          count: g.customers.length,
-          onClick: () => setActiveGroupId(g.id),
-        })),
-      ],
-    },
-  ]
 
   // list of currently selected customers of a group
   const [selectedCustomerIds, setSelectedCustomerIds] = useState(
@@ -169,7 +146,6 @@ function CustomerGroupCustomersList(props: CustomerGroupCustomersListProps) {
           paginate={paginate}
           setQuery={setQuery}
           customers={customers}
-          filteringOptions={filteringOptions}
           groupId={props.group.id}
           queryObject={queryObject}
           removeCustomers={removeCustomers}


### PR DESCRIPTION
**What**
- ~~use `/admin/customers` in combination with the `groups` param to fetch customers for the groups details page instead of using `/admin/customer-groups/:id/customers`~~ 
- remove customer groups filter on the details page
- set metadata filed to `null` if deleted

**Why**
- ~~`/admin/customer-groups/:id/customers` enforces a single `groups` id as a param by design but we have a use case on the CG customers table where we need customers that belong in 2 groups~~