### PR TITLE
Fix/accordion animation

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -389,6 +389,10 @@
   }
 }
 
+.h-accordion {
+  height: var(--radix-accordion-content-height);
+}
+
 /* Classes to remove number spinners from inputs of type number */
 /* Chrome, Safari, Edge, Opera */
 .remove-number-spinner::-webkit-outer-spin-button,

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -389,10 +389,6 @@
   }
 }
 
-.h-accordion {
-  height: var(--radix-accordion-content-height);
-}
-
 /* Classes to remove number spinners from inputs of type number */
 /* Chrome, Safari, Edge, Opera */
 .remove-number-spinner::-webkit-outer-spin-button,

--- a/src/components/organisms/accordion/accordion.stories.tsx
+++ b/src/components/organisms/accordion/accordion.stories.tsx
@@ -9,9 +9,14 @@ export default {
 } as ComponentMeta<typeof Accordion>
 
 const Template: ComponentStory<typeof Accordion> = (args) => (
-  <div className="max-w-3xl">
+  <div className="max-w-3xl max-h-6xlarge">
     <Accordion {...args}>
-      <Accordion.Item title={"General"} required value={"item.1"}>
+      <Accordion.Item
+        title={"General"}
+        required
+        value={"item.1"}
+        description="test 12342 "
+      >
         <div className="flex flex-col gap-y-small">
           <InputField label="First Name" />
           <InputField label="Last Name" />
@@ -22,6 +27,29 @@ const Template: ComponentStory<typeof Accordion> = (args) => (
         description="The price overrides apply from the time you hit the publish button and forever if left untouched."
         tooltip="You could add some useful information here."
         value={"item.2"}
+      >
+        <div className="flex flex-col gap-y-small">
+          <InputField label="Limit" />
+          <InputField label="Amount" />
+          <InputField label="Scale" />
+        </div>
+      </Accordion.Item>
+      <Accordion.Item
+        title="Prices"
+        description="The price overrides apply from the time you hit the publish button and forever if left untouched."
+        value={"item.3"}
+      >
+        <div className="flex flex-col gap-y-small">
+          <InputField label="Limit" />
+          <InputField label="Amount" />
+          <InputField label="Scale" />
+        </div>
+      </Accordion.Item>
+      <Accordion.Item
+        title="Metadata"
+        description="The price overrides apply from the time you hit the publish button and forever if left untouched."
+        tooltip="You could add some useful information here."
+        value={"item.4"}
       >
         <div className="flex flex-col gap-y-small">
           <InputField label="Limit" />

--- a/src/components/organisms/accordion/accordion.stories.tsx
+++ b/src/components/organisms/accordion/accordion.stories.tsx
@@ -46,6 +46,7 @@ const Template: ComponentStory<typeof Accordion> = (args) => (
         </div>
       </Accordion.Item>
       <Accordion.Item
+        forceMountContent
         title="Metadata"
         description="The price overrides apply from the time you hit the publish button and forever if left untouched."
         tooltip="You could add some useful information here."

--- a/src/components/organisms/accordion/index.tsx
+++ b/src/components/organisms/accordion/index.tsx
@@ -1,4 +1,5 @@
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import clsx from "clsx"
 import React from "react"
 import Button from "../../fundamentals/button"
 import InfoTooltip from "../../molecules/info-tooltip"
@@ -8,6 +9,7 @@ type AccordionItemProps = AccordionPrimitive.AccordionItemProps & {
   description?: string
   required?: boolean
   tooltip?: string
+  forceMountContent: true | undefined
 }
 
 const Accordion: React.FC<
@@ -29,6 +31,7 @@ const Item: React.FC<AccordionItemProps> = ({
   required,
   tooltip,
   children,
+  forceMountContent = undefined,
   ...props
 }) => {
   return (
@@ -48,17 +51,17 @@ const Item: React.FC<AccordionItemProps> = ({
           <MorphingTrigger />
         </AccordionPrimitive.Trigger>
       </AccordionPrimitive.Header>
-      <div className="group-radix-state-closed:h-0 group-radix-state-closed:opacity-0 group-radix-state-open:h-radix-accordion group-radix-state-open:opacity-100 transition-all duration-300 ease-accordion overflow-hidden">
-        <AccordionPrimitive.Content
-          forceMount
-          className="overflow-hidden radix-state-open:animate-accordion-open radix-state-closed:animate-accordion-close"
-        >
-          <div className="text-grey-50 inter-base-regular">
-            {description && <p>{description}</p>}
-            <div className="mt-large">{children}</div>
-          </div>
-        </AccordionPrimitive.Content>
-      </div>
+      <AccordionPrimitive.Content
+        forceMount={forceMountContent}
+        className={clsx(
+          "overflow-hidden radix-state-open:animate-accordion-open radix-state-closed:animate-accordion-close"
+        )}
+      >
+        <div className="text-grey-50 inter-base-regular group-radix-state-closed:animate-accordion-close">
+          {description && <p>{description}</p>}
+          <div className="mt-large">{children}</div>
+        </div>
+      </AccordionPrimitive.Content>
     </AccordionPrimitive.Item>
   )
 }

--- a/src/components/organisms/accordion/index.tsx
+++ b/src/components/organisms/accordion/index.tsx
@@ -3,81 +3,6 @@ import React from "react"
 import Button from "../../fundamentals/button"
 import InfoTooltip from "../../molecules/info-tooltip"
 
-// type AccordionItemProps = {
-//   title: string
-//   description?: string
-//   required?: boolean
-//   tooltip?: string
-// }
-
-// type AccordionProps = {
-//   /**
-//    * If true collapsed items will not be unmounted
-//    */
-//   keepMounted?: boolean
-// }
-
-// const Accordion: React.FC<AccordionProps> & {
-//   Item: React.FC<AccordionItemProps>
-// } = ({ children }) => {
-//   return (
-//     <div>
-//       {Children.map(children, (child, index) => (
-//         <div
-//           key={index}
-//           className="border-b border-grey-20 last:border-none pb-5xlarge mb-5 last:mb-0"
-//         >
-//           {child}
-//         </div>
-//       ))}
-//     </div>
-//   )
-// }
-
-// const Item: React.FC<AccordionItemProps> = ({
-//   title,
-//   description,
-//   required = false,
-//   tooltip,
-//   children,
-// }) => {
-//   const [open, setOpen] = useState(false)
-//   return (
-// <div>
-//   <div className="flex items-center justify-between">
-//     <div className="flex items-center gap-x-2xsmall">
-//       <span className="inter-large-semibold">
-//         {title}
-//         {required && <span className="text-rose-50">*</span>}
-//       </span>
-//       {tooltip && <InfoTooltip content={tooltip} />}
-//     </div>
-//     <Button
-//       variant="ghost"
-//       size="small"
-//       className="p-[6px]"
-//       onClick={() => setOpen(!open)}
-//     >
-//       {open ? <MinusIcon size={20} /> : <PlusIcon size={20} />}
-//     </Button>
-//   </div>
-//   <div className="text-grey-50 inter-base-regular">
-//     {description && <p>{description}</p>}
-//     <div
-//       className={clsx({
-//         "animate-fade-out-top": !open,
-//         "animate-fade-in-top": open,
-//       })}
-//     >
-//       {children}
-//     </div>
-//   </div>
-// </div>
-//   )
-// }
-
-// Accordion.Item = Item
-
 type AccordionItemProps = AccordionPrimitive.AccordionItemProps & {
   title: string
   description?: string
@@ -109,7 +34,7 @@ const Item: React.FC<AccordionItemProps> = ({
   return (
     <AccordionPrimitive.Item
       {...props}
-      className="border-b border-grey-20 transition- pb-5 radix-state-open:pb-5xlarge mb-5 last:mb-0 group"
+      className="border-b border-grey-20 transition-all pb-5 radix-state-open:pb-5xlarge mb-5 last:mb-0 group"
     >
       <AccordionPrimitive.Header>
         <AccordionPrimitive.Trigger className="flex items-center justify-between w-full">
@@ -123,8 +48,11 @@ const Item: React.FC<AccordionItemProps> = ({
           <MorphingTrigger />
         </AccordionPrimitive.Trigger>
       </AccordionPrimitive.Header>
-      <AccordionPrimitive.Content forceMount>
-        <div className="text-grey-50 inter-base-regular transition-all duration-300 h-radix-accordion opacity-100 group-radix-state-closed:h-0 overflow-hidden group-radix-state-closed:opacity-0">
+      <AccordionPrimitive.Content
+        forceMount
+        className="transition-all duration-300 h-accordion group-radix-state-closed:h-0 overflow-hidden"
+      >
+        <div className="text-grey-50 inter-base-regular transition-all duration-300 opacity-100 group-radix-state-closed:opacity-0">
           {description && <p>{description}</p>}
           <div className="mt-large">{children}</div>
         </div>

--- a/src/components/organisms/accordion/index.tsx
+++ b/src/components/organisms/accordion/index.tsx
@@ -34,7 +34,7 @@ const Item: React.FC<AccordionItemProps> = ({
   return (
     <AccordionPrimitive.Item
       {...props}
-      className="border-b border-grey-20 transition-all pb-5 radix-state-open:pb-5xlarge mb-5 last:mb-0 group"
+      className="border-b border-grey-20 transition-padding pb-5 radix-state-open:pb-5xlarge mb-5 last:mb-0 group"
     >
       <AccordionPrimitive.Header>
         <AccordionPrimitive.Trigger className="flex items-center justify-between w-full">
@@ -48,15 +48,17 @@ const Item: React.FC<AccordionItemProps> = ({
           <MorphingTrigger />
         </AccordionPrimitive.Trigger>
       </AccordionPrimitive.Header>
-      <AccordionPrimitive.Content
-        forceMount
-        className="transition-all duration-300 h-accordion group-radix-state-closed:h-0 overflow-hidden"
-      >
-        <div className="text-grey-50 inter-base-regular transition-all duration-300 opacity-100 group-radix-state-closed:opacity-0">
-          {description && <p>{description}</p>}
-          <div className="mt-large">{children}</div>
-        </div>
-      </AccordionPrimitive.Content>
+      <div className="group-radix-state-closed:h-0 group-radix-state-closed:opacity-0 group-radix-state-open:h-radix-accordion group-radix-state-open:opacity-100 transition-all duration-300 ease-accordion overflow-hidden">
+        <AccordionPrimitive.Content
+          forceMount
+          className="overflow-hidden radix-state-open:animate-accordion-open radix-state-closed:animate-accordion-close"
+        >
+          <div className="text-grey-50 inter-base-regular">
+            {description && <p>{description}</p>}
+            <div className="mt-large">{children}</div>
+          </div>
+        </AccordionPrimitive.Content>
+      </div>
     </AccordionPrimitive.Item>
   )
 }

--- a/src/components/organisms/accordion/index.tsx
+++ b/src/components/organisms/accordion/index.tsx
@@ -9,7 +9,7 @@ type AccordionItemProps = AccordionPrimitive.AccordionItemProps & {
   description?: string
   required?: boolean
   tooltip?: string
-  forceMountContent: true | undefined
+  forceMountContent?: true
 }
 
 const Accordion: React.FC<

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,12 @@ module.exports = {
         height: "height",
         bg: "background-color",
         display: "display opacity",
+        visibility: "visibility",
+        padding: "padding-top padding-right padding-bottom padding-left",
+        accordion: "height, opacity",
+      },
+      transitionTimingFunction: {
+        accordion: "cubic-bezier(0.87, 0, 0.13, 1)",
       },
       colors: {
         grey: {
@@ -289,18 +295,22 @@ module.exports = {
         },
         "accordion-slide-up": {
           "0%": {
-            height: "100px",
+            height: "var(--radix-accordion-content-height)",
+            opacity: "1",
           },
           "100%": {
             height: "0",
+            opacity: "0",
           },
         },
         "accordion-slide-down": {
           "0%": {
             height: "0",
+            opacity: "0",
           },
           "100%": {
-            height: "100px",
+            height: "var(--radix-accordion-content-height)",
+            opacity: "1",
           },
         },
         enter: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,10 +10,6 @@ module.exports = {
         display: "display opacity",
         visibility: "visibility",
         padding: "padding-top padding-right padding-bottom padding-left",
-        accordion: "height, opacity",
-      },
-      transitionTimingFunction: {
-        accordion: "cubic-bezier(0.87, 0, 0.13, 1)",
       },
       colors: {
         grey: {


### PR DESCRIPTION
**What**

Attempt at fixing accordion animation. Still not perfect, but this is the best solution I can come up with while maintaining `forceMount` on `Item.Content`.
It ensures that the open animation plays for all items, but it messes a bit with the close animation, still think it is acceptable though. See attached video:


https://user-images.githubusercontent.com/45367945/160386283-f2d06dd9-b073-46b1-830f-4ff014d26be5.mov


**Note** 

The open animation does not work in firefox and safari, see: https://github.com/radix-ui/primitives/issues/1265.