### PR TITLE
feat: table actions toaster

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,4 @@
+import { Toaster } from "react-hot-toast"
 import "../src/assets/styles/global.css"
 
 export const parameters = {
@@ -18,6 +19,24 @@ global.___loader = {
 global.__PATH_PREFIX__ = ""
 
 // This is to utilized to override the window.___navigate method Gatsby defines and uses to report what path a Link would be taking us to if it wasn't inside a storybook
-window.___navigate = pathname => {
+window.___navigate = (pathname) => {
   action("NavigateTo:")(pathname)
 }
+
+export const decorators = [
+  (Story) => {
+    return (
+      <>
+        <Story />
+        <Toaster
+          containerStyle={{
+            top: 74,
+            left: 24,
+            bottom: 24,
+            right: 24,
+          }}
+        />
+      </>
+    )
+  },
+]

--- a/src/components/declarative-toaster/declarative-toaster.stories.tsx
+++ b/src/components/declarative-toaster/declarative-toaster.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+import React from "react"
+import { TableToasterContainer } from "../molecules/table-toaster"
+import Toaster from "./"
+
+export default {
+  title: "Components/DeclarativeToaster",
+  component: Toaster,
+} as ComponentMeta<typeof Toaster>
+
+const Template: ComponentStory<typeof Toaster> = (args) => (
+  <div className="flex justify-center">
+    <span>Toggle the visible control below to show the toaster</span>
+    <Toaster {...args}>
+      <TableToasterContainer>
+        <span className="text-grey-0">Helloooo</span>
+      </TableToasterContainer>
+    </Toaster>
+  </div>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  visible: false,
+  duration: Infinity,
+  position: "bottom-center",
+}

--- a/src/components/declarative-toaster/index.tsx
+++ b/src/components/declarative-toaster/index.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { toast, ToastOptions } from "react-hot-toast"
+
+export type ToasterProps = {
+  visible: boolean
+  children: React.ReactElement
+} & ToastOptions
+
+const Toaster = ({ visible, children, ...options }: ToasterProps) => {
+  React.useEffect(() => {
+    if (visible) {
+      toast.custom((t) => React.cloneElement(children, { toast: t }), {
+        ...options,
+      })
+    } else {
+      toast.dismiss(options.id)
+    }
+  }, [visible, children])
+
+  return null
+}
+
+export default Toaster

--- a/src/components/fundamentals/icons/backspace-icon/backspace-icon.stories.tsx
+++ b/src/components/fundamentals/icons/backspace-icon/backspace-icon.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentMeta } from "@storybook/react"
+import React from "react"
+import BackspaceIcon from "."
+
+export default {
+  title: "Fundamentals/Icons/BackspaceIcon",
+  component: BackspaceIcon,
+  argTypes: {
+    size: {
+      control: {
+        type: "select",
+        options: ["24", "20", "16"],
+      },
+    },
+  },
+} as ComponentMeta<typeof BackspaceIcon>
+
+const Template = (args) => <BackspaceIcon {...args} />
+
+export const Icon = Template.bind({})
+Icon.args = {
+  size: "16",
+  color: "currentColor",
+}

--- a/src/components/fundamentals/icons/backspace-icon/index.tsx
+++ b/src/components/fundamentals/icons/backspace-icon/index.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import IconProps from "../types/icon-type"
+
+const BackspaceIcon: React.FC<IconProps> = ({
+  size = "16",
+  color = "currentColor",
+  ...attributes
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.5 6.66675L10.1667 9.33341"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M10.1667 6.66675L7.5 9.33341"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M4.56137 11.8559L2.55004 9.49392H2.55004C1.81665 8.63293 1.81665 7.36691 2.55004 6.50592L4.56137 4.14392V4.14392C4.9991 3.62949 5.64058 3.33312 6.31604 3.33325H11.6954V3.33325C12.9682 3.33325 14 4.36509 14 5.63792C14 5.63792 14 5.63792 14 5.63792V10.3619V10.3619C14 11.6348 12.9682 12.6666 11.6954 12.6666H6.31604V12.6666C5.64058 12.6667 4.99911 12.3704 4.56137 11.8559V11.8559Z"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default BackspaceIcon

--- a/src/components/fundamentals/icons/backspace-icon/index.tsx
+++ b/src/components/fundamentals/icons/backspace-icon/index.tsx
@@ -17,23 +17,23 @@ const BackspaceIcon: React.FC<IconProps> = ({
       <path
         d="M7.5 6.66675L10.1667 9.33341"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M10.1667 6.66675L7.5 9.33341"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M4.56137 11.8559L2.55004 9.49392H2.55004C1.81665 8.63293 1.81665 7.36691 2.55004 6.50592L4.56137 4.14392V4.14392C4.9991 3.62949 5.64058 3.33312 6.31604 3.33325H11.6954V3.33325C12.9682 3.33325 14 4.36509 14 5.63792C14 5.63792 14 5.63792 14 5.63792V10.3619V10.3619C14 11.6348 12.9682 12.6666 11.6954 12.6666H6.31604V12.6666C5.64058 12.6667 4.99911 12.3704 4.56137 11.8559V11.8559Z"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   )

--- a/src/components/molecules/hot-key-action/hot-key-action.stories.tsx
+++ b/src/components/molecules/hot-key-action/hot-key-action.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+import React from "react"
+import HotKeyAction from "."
+import BackspaceIcon from "../../fundamentals/icons/backspace-icon"
+
+export default {
+  title: "Molecules/HotKeyAction",
+} as ComponentMeta<typeof HotKeyAction>
+
+const Template: ComponentStory<typeof HotKeyAction> = (args) => (
+  <div className="flex bg-grey-80 p-base">
+    <HotKeyAction {...args} />
+  </div>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  label: "Unpublish",
+  icon: "U",
+  hotKey: "U",
+  onAction: () => alert("U key pressed!"),
+}
+
+export const WithIcon = Template.bind({})
+WithIcon.args = {
+  label: "Delete",
+  icon: <BackspaceIcon />,
+  hotKey: "backspace",
+  onAction: () => alert("backspace key pressed!"),
+}

--- a/src/components/molecules/hot-key-action/index.tsx
+++ b/src/components/molecules/hot-key-action/index.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import { useHotkeys } from "react-hotkeys-hook"
+
+type HotKeyActionProps = {
+  label: string
+  hotKey: string
+  icon: React.ReactNode
+  onAction: (keyboardEvent: KeyboardEvent, hotkeysEvent: any) => void | boolean
+}
+
+const HotKeyAction = ({ label, hotKey, icon, onAction }: HotKeyActionProps) => {
+  useHotkeys(hotKey, onAction, {})
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-grey-0 inter-small-semibold">{label}</span>
+      <div className="inter-small-semibold text-grey-30 flex items-center justify-center w-[24px] h-[24px] rounded bg-grey-70">
+        {icon}
+      </div>
+    </div>
+  )
+}
+
+export default HotKeyAction

--- a/src/components/molecules/table-toaster/index.tsx
+++ b/src/components/molecules/table-toaster/index.tsx
@@ -1,7 +1,6 @@
 import clsx from "clsx"
 import React from "react"
 import { Toast } from "react-hot-toast"
-import { useHotkeys } from "react-hotkeys-hook"
 
 export type TableToasterContainerProps = {
   children: React.ReactElement[] | React.ReactElement | React.ReactNode
@@ -22,18 +21,6 @@ export const TableToasterContainer = ({
     >
       <div className="flex items-center rounded-rounded bg-grey-90 px-base py-3.5">
         {children}
-      </div>
-    </div>
-  )
-}
-
-export const HotKeyAction = ({ label, hotKey, icon, onAction }) => {
-  useHotkeys(hotKey, onAction, {})
-  return (
-    <div className="flex items-center gap-2">
-      <span className="text-grey-0 inter-small-semibold">{label}</span>
-      <div className="inter-small-semibold text-grey-30 flex items-center justify-center w-[24px] h-[24px] rounded bg-grey-70">
-        {icon}
       </div>
     </div>
   )

--- a/src/components/molecules/table-toaster/index.tsx
+++ b/src/components/molecules/table-toaster/index.tsx
@@ -1,0 +1,40 @@
+import clsx from "clsx"
+import React from "react"
+import { Toast } from "react-hot-toast"
+import { useHotkeys } from "react-hotkeys-hook"
+
+export type TableToasterContainerProps = {
+  children: React.ReactElement[] | React.ReactElement | React.ReactNode
+  toast?: Toast
+}
+
+export const TableToasterContainer = ({
+  children,
+  toast,
+}: TableToasterContainerProps) => {
+  return (
+    <div
+      className={clsx({
+        "animate-enter": toast?.visible,
+        "animate-leave": !toast?.visible,
+      })}
+      {...toast?.ariaProps}
+    >
+      <div className="flex items-center rounded-rounded bg-grey-90 px-base py-3.5">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export const HotKeyAction = ({ label, hotKey, icon, onAction }) => {
+  useHotkeys(hotKey, onAction, {})
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-grey-0 inter-small-semibold">{label}</span>
+      <div className="inter-small-semibold text-grey-30 flex items-center justify-center w-[24px] h-[24px] rounded bg-grey-70">
+        {icon}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### What

- adds a declarative `Toaster` component
- adds a `HotKeyAction` component
- adds a `TableToasterContainer` component

### Why
- `react-hot-toast` provides an imperative API for dealing with toasters. Although this is very useful and nice for a lot of use cases (i.e: onError/onSuccess callbacks), sometimes, it might be better to have a declarative approach. For example, when handling table "batch" actions (i.e: select multiple rows then delete), `react-table` will return a `selectedFlatRows` field which will hold all the rows which are currently selected. We can use this piece of state to determine whether we should render a toaster or not. Instead of making a `useEffect` and subscribing to some piece of state everytime we want to use it this way, I have abstracted this functionality in a `<Toaster visible={your_state} />` component

- The `HotKeyAction` component is a simple component which is responsible for rendering a label (to describe what the hot key does) and an icon. It also take a `hotKey` and `onAction` props which will be used to map the given `onAction` callback to the given hotkey. 

- The `TableToasterContainer` component is the toaster container which will wrap any children components. 