### PR TITLE
fix: modal showing unintentionally in prod and housekeeping

### DIFF
--- a/src/domain/settings/regions/details.tsx
+++ b/src/domain/settings/regions/details.tsx
@@ -184,6 +184,7 @@ const RegionDetails = ({ id, onDelete, handleSelect }) => {
       fulfillment_providers: region.fulfillment_providers.map((f) => f.id),
       countries: [], // As countries can't belong to more than one region at the same time we can just pass an empty array
       name: `${region.name} Copy`,
+      tax_rate: region.tax_rate,
     }
 
     createRegion.mutate(payload, {

--- a/src/domain/settings/regions/edit-shipping.tsx
+++ b/src/domain/settings/regions/edit-shipping.tsx
@@ -208,7 +208,7 @@ const EditShipping = ({ shippingOption, region, onDone, onClick }) => {
                     <CurrencyInput.AmountInput
                       amount={shippingOption.amount}
                       label="Price"
-                      onChange={handleAmountChange}
+                      onChange={(amount) => handleAmountChange(amount)}
                     />
                   </CurrencyInput>
                 </div>
@@ -240,7 +240,7 @@ const EditShipping = ({ shippingOption, region, onDone, onClick }) => {
                             shippingOption.requirements?.min_subtotal?.amount
                           }
                           label="Min. subtotal"
-                          onChange={handleMinChange}
+                          onChange={(amount) => handleMinChange(amount)}
                         />
                       </CurrencyInput>
                       <CurrencyInput
@@ -253,7 +253,7 @@ const EditShipping = ({ shippingOption, region, onDone, onClick }) => {
                             shippingOption.requirements?.max_subtotal?.amount
                           }
                           label="Max. subtotal"
-                          onChange={handleMaxChange}
+                          onChange={(amount) => handleMaxChange(amount)}
                         />
                       </CurrencyInput>
                     </div>
@@ -274,15 +274,15 @@ const EditShipping = ({ shippingOption, region, onDone, onClick }) => {
                 </div>
               </Modal.Content>
               <Modal.Footer>
-                <div className="flex items-center justify-end w-full">
+                <div className="flex items-center justify-end w-full gap-x-xsmall">
                   <Button
                     type="button"
                     onClick={onClick}
-                    variant="ghost"
+                    variant="secondary"
                     size="small"
                     className="w-eventButton justify-center"
                   >
-                    Cancel Changes
+                    Cancel changes
                   </Button>
                   <Button
                     type="submit"

--- a/src/domain/settings/regions/new-shipping.tsx
+++ b/src/domain/settings/regions/new-shipping.tsx
@@ -273,11 +273,11 @@ const NewShipping = ({ isReturn, region, onCreated, onClick }) => {
             )}
           </Modal.Content>
           <Modal.Footer>
-            <div className="flex justify-end w-full">
+            <div className="flex justify-end w-full gap-x-xsmall">
               <Button
-                variant="ghost"
+                variant="secondary"
                 size="small"
-                className="justify-center w-[130px]"
+                className="justify-center w-eventButton"
                 onClick={onClick}
               >
                 Cancel
@@ -286,7 +286,7 @@ const NewShipping = ({ isReturn, region, onCreated, onClick }) => {
                 type="submit"
                 variant="primary"
                 size="small"
-                className="justify-center w-[130px]"
+                className="justify-center w-eventButton"
               >
                 Save
               </Button>

--- a/src/domain/settings/regions/new.tsx
+++ b/src/domain/settings/regions/new.tsx
@@ -195,11 +195,11 @@ const NewRegion = ({ onDone, onClick }) => {
             </div>
           </Modal.Content>
           <Modal.Footer>
-            <div className="flex items-center justify-end w-full">
+            <div className="flex items-center justify-end w-full gap-x-xsmall">
               <Button
                 type="button"
                 onClick={onClick}
-                variant="ghost"
+                variant="secondary"
                 size="small"
                 className="w-eventButton justify-center"
               >

--- a/src/domain/settings/regions/shipping.tsx
+++ b/src/domain/settings/regions/shipping.tsx
@@ -1,25 +1,21 @@
-import {
-  useAdminRegionFulfillmentOptions,
-  useAdminShippingOptions,
-} from "medusa-react"
+import { Region, ShippingOption as Option } from "@medusajs/medusa"
+import { useAdminShippingOptions } from "medusa-react"
 import React, { useState } from "react"
-import { Box, Flex } from "rebass"
+import Spinner from "../../../components/atoms/spinner"
 import PlusIcon from "../../../components/fundamentals/icons/plus-icon"
 import Actionables from "../../../components/molecules/actionables"
 import ShippingOption from "../../../components/molecules/shipping-option"
-import Spinner from "../../../components/spinner"
 import EditShipping from "./edit-shipping"
 import NewShipping from "./new-shipping"
 
-const Shipping = ({ region }) => {
-  const [editOption, setEditOption] = useState(null)
+type ShippingProps = {
+  region: Region
+}
+
+const Shipping: React.FC<ShippingProps> = ({ region }) => {
+  const [editOption, setEditOption] = useState<Option | null>(null)
   const [showAddOption, setAddOption] = useState(false)
   const [showAddReturnOption, setAddReturnOption] = useState(false)
-
-  const {
-    fulfillment_options,
-    isLoading: loadingFulfillment,
-  } = useAdminRegionFulfillmentOptions(region.id)
 
   const {
     shipping_options,
@@ -43,8 +39,8 @@ const Shipping = ({ region }) => {
     },
   ]
 
-  const outbound = []
-  const inbound = []
+  const outbound: Option[] = []
+  const inbound: Option[] = []
   if (shipping_options) {
     for (const o of shipping_options) {
       if (o.is_return) {
@@ -64,16 +60,11 @@ const Shipping = ({ region }) => {
         </div>
         <div className="flex flex-col">
           {!shipping_options ? (
-            <Flex
-              flexDirection="column"
-              alignItems="center"
-              height="100vh"
-              mt="auto"
-            >
-              <Box height="75px" width="75px" mt="50%">
-                <Spinner dark />
-              </Box>
-            </Flex>
+            <div className="flex items-center justify-center h-screen">
+              <div className="m-auto">
+                <Spinner variant="secondary" />
+              </div>
+            </div>
           ) : (
             shipping_options
               .filter((o) => o.is_return === false && o.region_id === region.id)
@@ -98,16 +89,11 @@ const Shipping = ({ region }) => {
         </div>
         <div className="flex flex-col">
           {loadingOptions ? (
-            <Flex
-              flexDirection="column"
-              alignItems="center"
-              height="100vh"
-              mt="auto"
-            >
-              <Box height="75px" width="75px" mt="50%">
-                <Spinner dark />
-              </Box>
-            </Flex>
+            <div className="flex items-center justify-center h-screen">
+              <div className="m-auto">
+                <Spinner variant="secondary" />
+              </div>
+            </div>
           ) : shipping_options ? (
             shipping_options
               .filter((o) => o.is_return && o.region_id === region.id)
@@ -133,7 +119,7 @@ const Shipping = ({ region }) => {
           region={region}
         />
       )}
-      {(showAddOption || showAddReturnOption || loadingFulfillment) && (
+      {(showAddOption || showAddReturnOption) && (
         <NewShipping
           isReturn={showAddReturnOption}
           onClick={() =>
@@ -143,7 +129,6 @@ const Shipping = ({ region }) => {
           }
           onCreated={refetch}
           region={region}
-          fulfillmentOptions={fulfillment_options}
         />
       )}
     </>


### PR DESCRIPTION
**What**

- Prevents Add Shipping Option modal from showing when changing between regions in prod (tested by building and serving site)
- General housekeeping of the region domain:
  - fixed some ts errors
  - updated the look of the cancel buttons in modals to reflect latest changes to design in Figma