### PR TITLE
fix: radio group styling

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -160,7 +160,7 @@
     @apply font-mono text-xsmall leading-xsmall font-bold;
   }
 
-  .radio-outer-ring > span[data-state="checked"] {
+  .radio-outer-ring > span.indicator[data-state="checked"] {
     @apply rounded-circle shadow-[#7C3AED] shadow-[0_0_0_2px];
   }
 }

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -161,7 +161,7 @@
   }
 
   .radio-outer-ring > span.indicator[data-state="checked"] {
-    @apply rounded-circle shadow-[#7C3AED] shadow-[0_0_0_2px];
+    @apply rounded-circle shadow-violet-60 shadow-[0_0_0_2px];
   }
 }
 

--- a/src/components/organisms/radio-group/index.tsx
+++ b/src/components/organisms/radio-group/index.tsx
@@ -27,7 +27,8 @@ const Item = ({
   return (
     <label
       className={clsx(
-        "rounded-base border border-grey-20 p-base flex items-start mb-xsmall gap-base cursor-pointer", className
+        "rounded-base relative border border-grey-20 p-base flex items-start mb-xsmall gap-base cursor-pointer",
+        className
       )}
       htmlFor={rest.value}
     >
@@ -41,8 +42,14 @@ const Item = ({
       >
         <RadioGroupPrimitive.Indicator
           className={clsx(
-            "flex items-center justify-center w-full h-full relative",
+            "indicator flex items-center justify-center w-full h-full relative",
             "after:absolute after:inset-0 after:m-auto after:block after:w-[12px] after:h-[12px] after:bg-violet-60 after:rounded-circle"
+          )}
+        />
+        <RadioGroupPrimitive.Indicator
+          aria-hidden="true"
+          className={clsx(
+            "absolute inset-0 shadow-[#7C3AED] shadow-[0_0_0_2px] rounded-base"
           )}
         />
       </RadioGroupPrimitive.Item>

--- a/src/components/organisms/radio-group/index.tsx
+++ b/src/components/organisms/radio-group/index.tsx
@@ -46,10 +46,12 @@ const Item = ({
             "after:absolute after:inset-0 after:m-auto after:block after:w-[12px] after:h-[12px] after:bg-violet-60 after:rounded-circle"
           )}
         />
+        {/* Outline indicator: purely stylistical */}
         <RadioGroupPrimitive.Indicator
+          //  we want to hide this indicator from screen readers because the previous one is enough
           aria-hidden="true"
           className={clsx(
-            "absolute inset-0 shadow-[#7C3AED] shadow-[0_0_0_2px] rounded-base"
+            "absolute inset-0 shadow-violet-60 shadow-[0_0_0_2px] rounded-base"
           )}
         />
       </RadioGroupPrimitive.Item>


### PR DESCRIPTION
### What

- add a border to radio item when selected

### How

- Given that the label element is actually a parent of the radio component, there is no css selector for selecting the parent when the radio is checked. The solution adds an extra `RadioPrimitive.Indicator` which is purely stylistic. It simply renders a violet outline on the parent. The `RadioPrimitive.Indicator` is a component which radix renders when the radio item is checked. You can think about having two instances of this component as a way of saying "when the radio is selected, indicate this by rendering an outline + a little radio icon"

would love to hear if any of you guys can come up with a cleaner and more elegant solution!