### PR TITLE
add: generic table for promotion conditions

### DIFF
--- a/src/domain/discounts/discount-form/condition-tables/products.tsx
+++ b/src/domain/discounts/discount-form/condition-tables/products.tsx
@@ -1,6 +1,7 @@
+import { Product } from "@medusajs/medusa"
 import { useAdminProducts } from "medusa-react"
 import React, { useContext, useMemo, useState } from "react"
-import { Row } from "react-table"
+import { Column, Row } from "react-table"
 import Spinner from "../../../../components/atoms/spinner"
 import Button from "../../../../components/fundamentals/button"
 import ImagePlaceholder from "../../../../components/fundamentals/image-placeholder"
@@ -26,7 +27,7 @@ const getProductStatusVariant = (status) => {
   }
 }
 
-const ProductRow = ({ row }: { row: Row }) => {
+const ProductRow = ({ row }: { row: Row<Product> }) => {
   return (
     <Table.Row {...row.getRowProps()}>
       {row.cells.map((cell) => {
@@ -70,7 +71,7 @@ const ProductConditionSelector = ({ onClose }) => {
     )
   }
 
-  const columns = useMemo(() => {
+  const columns = useMemo<Column<Product>[]>(() => {
     return [
       {
         Header: "Name",
@@ -108,13 +109,6 @@ const ProductConditionSelector = ({ onClose }) => {
               .toUpperCase()}${original.status.slice(1)}`}
             variant={getProductStatusVariant(original.status)}
           />
-        ),
-      },
-      {
-        Header: <div className="text-right">In Stock</div>,
-        accessor: "inventory_quantity",
-        Cell: ({ row: { original } }) => (
-          <div className="text-right">{original.inventory_quantity}</div>
         ),
       },
     ]

--- a/src/domain/discounts/discount-form/condition-tables/selectable-table.tsx
+++ b/src/domain/discounts/discount-form/condition-tables/selectable-table.tsx
@@ -5,25 +5,32 @@ import {
   ProductTag,
   ProductType,
 } from "@medusajs/medusa"
-import React, { useEffect, useMemo } from "react"
+import { debounce } from "lodash"
+import React, { useEffect } from "react"
 import {
-  ColumnInstance,
+  Column,
+  HeaderGroup,
+  Row,
   usePagination,
   useRowSelect,
   useTable,
 } from "react-table"
 import Spinner from "../../../../components/atoms/spinner"
 import IndeterminateCheckbox from "../../../../components/molecules/indeterminate-checkbox"
-import Table, { TablePagination } from "../../../../components/molecules/table"
-import { PaginationProps } from "../../../../types/shared"
+import Table, {
+  TablePagination,
+  TableProps,
+} from "../../../../components/molecules/table"
+import useQueryFilters from "../../../../hooks/use-query-filters"
 
 type SelectableTableProps = {
-  showSearch?: boolean
-  objectName?: string
+  resourceName?: string
   label?: string
   isLoading?: boolean
-  pagination: PaginationProps
-  totalCount?: number
+  totalCount: number
+  options: Omit<TableProps, "filteringOptions"> & {
+    filters?: Pick<TableProps, "filteringOptions">
+  }
   data?:
     | Product[]
     | ProductType[]
@@ -31,171 +38,150 @@ type SelectableTableProps = {
     | ProductTag[]
     | CustomerGroup[]
   selectedIds?: string[]
-  columns: Partial<ColumnInstance>[]
-  onPaginationChange: (pagination: PaginationProps) => void
+  columns: Column[]
   onChange: (items: string[]) => void
-  onSearch?: (search: string) => void
-}
+  renderRow: (props: { row: Row }) => React.ReactElement
+  renderHeaderGroup?: (props: {
+    headerGroup: HeaderGroup
+  }) => React.ReactElement
+} & ReturnType<typeof useQueryFilters>
 
 export const SelectableTable: React.FC<SelectableTableProps> = ({
-  showSearch = true,
   label,
-  objectName,
+  resourceName = "",
   selectedIds = [],
   isLoading,
-  pagination,
-  totalCount,
+  totalCount = 0,
   data,
   columns,
-  onPaginationChange,
   onChange,
-  onSearch,
+  options,
+  renderRow,
+  renderHeaderGroup,
+  setQuery,
+  queryObject,
+  paginate,
 }) => {
-  const handleQueryChange = (newQuery) => {
-    onPaginationChange(newQuery)
-  }
-
-  const currentPage = useMemo(() => {
-    return Math.floor(pagination.offset / pagination.limit)
-  }, [pagination])
-
-  const numPages = useMemo(() => {
-    if (totalCount && pagination.limit) {
-      return Math.ceil(totalCount / pagination.limit)
-    }
-    return 0
-  }, [totalCount, pagination])
-
-  const {
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    rows,
-    prepareRow,
-    canPreviousPage,
-    canNextPage,
-    pageCount,
-    nextPage,
-    previousPage,
-    // Get the state from the instance
-    state: { pageIndex, pageSize, selectedRowIds },
-  } = useTable(
+  const table = useTable(
     {
       columns,
       data: data || [],
       manualPagination: true,
       initialState: {
-        pageIndex: currentPage,
-        pageSize: pagination.limit,
+        pageIndex: queryObject.offset / queryObject.limit,
+        pageSize: queryObject.limit,
         selectedRowIds: selectedIds.reduce((prev, id) => {
           prev[id] = true
           return prev
         }, {}),
       },
-      pageCount: numPages,
+      pageCount: Math.ceil(totalCount / queryObject.limit),
       autoResetSelectedRows: false,
       autoResetPage: false,
-      getRowId: (row) => row.id,
+      getRowId: (row: any) => row.id,
     },
     usePagination,
     useRowSelect,
-    (hooks) => {
-      hooks.visibleColumns.push((columns) => [
-        // Let's make a column for selection
-        {
-          id: "selection",
-          // The header can use the table's getToggleAllRowsSelectedProps method
-          // to render a checkbox
-          Header: ({ getToggleAllRowsSelectedProps }) => {
-            return (
-              <div>
-                <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} />
-              </div>
-            )
-          },
-          // The cell can use the individual row's getToggleRowSelectedProps method
-          // to the render a checkbox
-          Cell: ({ row }) => {
-            return (
-              <div>
-                <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
-              </div>
-            )
-          },
-        },
-        ...columns,
-      ])
-    }
+    useSelectionColumn
   )
 
   useEffect(() => {
-    onChange(Object.keys(selectedRowIds))
-  }, [selectedRowIds])
+    console.log({ selectedRowIDs: table.state.selectedRowIds })
+    onChange(Object.keys(table.state.selectedRowIds))
+  }, [table.state.selectedRowIds])
 
   const handleNext = () => {
-    if (canNextPage) {
-      handleQueryChange({
-        ...pagination,
-        offset: pagination.offset + pagination.limit,
-      })
-      nextPage()
+    if (!table.canNextPage) {
+      return
     }
+
+    paginate(1)
+    table.nextPage()
   }
 
   const handlePrev = () => {
-    if (canPreviousPage) {
-      handleQueryChange({
-        ...pagination,
-        offset: Math.max(pagination.offset - pagination.limit, 0),
-      })
-      previousPage()
+    if (!table.canPreviousPage) {
+      return
+    }
+
+    paginate(-1)
+    table.previousPage()
+  }
+
+  const handleSearch = (text: string) => {
+    setQuery(text)
+
+    if (text) {
+      table.gotoPage(0)
     }
   }
+
+  const debouncedSearch = React.useMemo(() => debounce(handleSearch, 300), [])
 
   return (
     <div>
       <div className="inter-base-semibold my-large">{label}</div>
       <Table
-        immediateSearchFocus={showSearch}
-        enableSearch={showSearch}
-        searchPlaceholder="Search Products.."
-        handleSearch={onSearch}
-        {...getTableProps()}
+        {...options}
+        {...table.getTableProps()}
+        handleSearch={options.enableSearch ? debouncedSearch : undefined}
       >
-        <Table.Body {...getTableBodyProps()}>
+        {renderHeaderGroup && (
+          <Table.Head>
+            {table.headerGroups?.map((headerGroup) =>
+              renderHeaderGroup({ headerGroup })
+            )}
+          </Table.Head>
+        )}
+
+        <Table.Body {...table.getTableBodyProps()}>
           {isLoading ? (
             <Spinner size="large" />
           ) : (
-            rows.map((row, i) => {
-              prepareRow(row)
-              return (
-                <Table.Row {...row.getRowProps()}>
-                  {row.cells.map((cell) => {
-                    return (
-                      <Table.Cell {...cell.getCellProps()}>
-                        {cell.render("Cell")}
-                      </Table.Cell>
-                    )
-                  })}
-                </Table.Row>
-              )
+            table.rows.map((row, i) => {
+              table.prepareRow(row)
+              return renderRow({ row })
             })
           )}
         </Table.Body>
       </Table>
+
       <TablePagination
         count={totalCount!}
-        limit={pagination.limit}
-        offset={pagination.offset}
-        pageSize={pagination.offset + rows.length}
-        title={objectName}
-        currentPage={pageIndex + 1}
-        pageCount={pageCount}
+        limit={queryObject.limit}
+        offset={queryObject.offset}
+        pageSize={queryObject.offset + table.rows.length}
+        title={resourceName}
+        currentPage={table.state.pageIndex + 1}
+        pageCount={table.pageCount}
         nextPage={handleNext}
         prevPage={handlePrev}
-        hasNext={canNextPage}
-        hasPrev={canPreviousPage}
+        hasNext={table.canNextPage}
+        hasPrev={table.canPreviousPage}
       />
     </div>
   )
+}
+
+const useSelectionColumn = (hooks) => {
+  hooks.visibleColumns.push((columns) => [
+    {
+      id: "selection",
+      Header: ({ getToggleAllRowsSelectedProps }) => {
+        return (
+          <div>
+            <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} />
+          </div>
+        )
+      },
+      Cell: ({ row }) => {
+        return (
+          <div>
+            <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
+          </div>
+        )
+      },
+    },
+    ...columns,
+  ])
 }

--- a/src/domain/discounts/discount-form/condition-tables/selectable-table.tsx
+++ b/src/domain/discounts/discount-form/condition-tables/selectable-table.tsx
@@ -1,10 +1,3 @@
-import {
-  CustomerGroup,
-  Product,
-  ProductCollection,
-  ProductTag,
-  ProductType,
-} from "@medusajs/medusa"
 import { debounce } from "lodash"
 import React, { useEffect } from "react"
 import {
@@ -23,7 +16,7 @@ import Table, {
 } from "../../../../components/molecules/table"
 import useQueryFilters from "../../../../hooks/use-query-filters"
 
-type SelectableTableProps = {
+type SelectableTableProps<T extends object> = {
   resourceName?: string
   label?: string
   isLoading?: boolean
@@ -31,22 +24,17 @@ type SelectableTableProps = {
   options: Omit<TableProps, "filteringOptions"> & {
     filters?: Pick<TableProps, "filteringOptions">
   }
-  data?:
-    | Product[]
-    | ProductType[]
-    | ProductCollection[]
-    | ProductTag[]
-    | CustomerGroup[]
+  data?: T[]
   selectedIds?: string[]
-  columns: Column[]
+  columns: Column<T>[]
   onChange: (items: string[]) => void
-  renderRow: (props: { row: Row }) => React.ReactElement
+  renderRow: (props: { row: Row<T> }) => React.ReactElement
   renderHeaderGroup?: (props: {
-    headerGroup: HeaderGroup
+    headerGroup: HeaderGroup<T>
   }) => React.ReactElement
 } & ReturnType<typeof useQueryFilters>
 
-export const SelectableTable: React.FC<SelectableTableProps> = ({
+export const SelectableTable = <T extends object>({
   label,
   resourceName = "",
   selectedIds = [],
@@ -61,8 +49,8 @@ export const SelectableTable: React.FC<SelectableTableProps> = ({
   setQuery,
   queryObject,
   paginate,
-}) => {
-  const table = useTable(
+}: SelectableTableProps<T>) => {
+  const table = useTable<T>(
     {
       columns,
       data: data || [],
@@ -73,7 +61,7 @@ export const SelectableTable: React.FC<SelectableTableProps> = ({
         selectedRowIds: selectedIds.reduce((prev, id) => {
           prev[id] = true
           return prev
-        }, {}),
+        }, {} as Record<string, boolean>),
       },
       pageCount: Math.ceil(totalCount / queryObject.limit),
       autoResetSelectedRows: false,

--- a/src/domain/discounts/discount-form/condition-tables/selectable-table.tsx
+++ b/src/domain/discounts/discount-form/condition-tables/selectable-table.tsx
@@ -1,3 +1,9 @@
+import {
+  CustomerGroup,
+  Product,
+  ProductCollection,
+  ProductTag,
+} from "@medusajs/medusa"
 import { debounce } from "lodash"
 import React, { useEffect } from "react"
 import {
@@ -6,6 +12,7 @@ import {
   Row,
   usePagination,
   useRowSelect,
+  useSortBy,
   useTable,
 } from "react-table"
 import Spinner from "../../../../components/atoms/spinner"
@@ -34,7 +41,9 @@ type SelectableTableProps<T extends object> = {
   }) => React.ReactElement
 } & ReturnType<typeof useQueryFilters>
 
-export const SelectableTable = <T extends object>({
+export const SelectableTable = <
+  T extends Product | CustomerGroup | ProductCollection | ProductTag
+>({
   label,
   resourceName = "",
   selectedIds = [],
@@ -68,6 +77,7 @@ export const SelectableTable = <T extends object>({
       autoResetPage: false,
       getRowId: (row: any) => row.id,
     },
+    useSortBy,
     usePagination,
     useRowSelect,
     useSelectionColumn
@@ -157,14 +167,14 @@ const useSelectionColumn = (hooks) => {
       id: "selection",
       Header: ({ getToggleAllRowsSelectedProps }) => {
         return (
-          <div>
+          <div className="flex justify-center">
             <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} />
           </div>
         )
       },
       Cell: ({ row }) => {
         return (
-          <div>
+          <div className="flex justify-center">
             <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
           </div>
         )


### PR DESCRIPTION
### What

- adds a generic table to be used for different promotion condition modals
- uses same approach as customer-groups + price lists
- supports optional headers
- supports optional filtering
- supports custom rows + headers through the `renderRow` and `renderHeaderGroup` props
- automatically debounces search terms



