### PR TITLE
fix: use default store currency when creating variant price

### DIFF
--- a/src/domain/products/details/variants/variant-editor.tsx
+++ b/src/domain/products/details/variants/variant-editor.tsx
@@ -48,11 +48,19 @@ const VariantEditor = ({
     appendPrice,
     deletePrice,
     availableCurrencies,
-  } = usePricesFieldArray(store?.currencies.map((c) => c.code) || [], {
-    control,
-    name: "prices",
-    keyName: "indexId",
-  })
+  } = usePricesFieldArray(
+    store?.currencies.map((c) => c.code) || [],
+    {
+      control,
+      name: "prices",
+      keyName: "indexId",
+    },
+    {
+      defaultAmount: 1000,
+      defaultCurrencyCode:
+        store?.default_currency.code || store?.currencies[0].code || "usd",
+    }
+  )
 
   const { fields } = useFieldArray({
     control,


### PR DESCRIPTION
## What
The 'Add variant' dialog now uses the default store currency when adding a price
## Why
Fixes #525 
## How
By passing the store configuration parameters to `usePricesFieldArray`
## Testing
The change has been manually tested against a fresh Medusa 1.2.1 instance configured with Postgres:
- [x] Set the store to only have one currency, and mark that currency as default. Verify that price is created with that currency.
- [x] Add multiple currencies to the store, set one as default. Verify that price is created with the default currency.
- [x] Change the default currency. Verify that subsequent prices are created with the new default (without restart).

## Other
Modified file formatted using ESLint/Prettier with repository provided config
