### PR TITLE
Fix: add `is_giftcard=false` to default query parameters

### DIFF
--- a/src/components/templates/product-table/index.tsx
+++ b/src/components/templates/product-table/index.tsx
@@ -20,6 +20,7 @@ type ProductTableProps = {}
 const defaultQueryProps = {
   fields: "id,title,type,thumbnail",
   expand: "variants,options,variants.prices,variants.options,collection,tags",
+  is_giftcard: false,
 }
 
 const ProductTable: React.FC<ProductTableProps> = () => {


### PR DESCRIPTION
**What**
- add `is_giftcard=false` to default query params for products