### PR TITLE
Fix: Remove default "published" from update mapper in products

### DIFF
--- a/src/domain/products/product-form/form/mappers.ts
+++ b/src/domain/products/product-form/form/mappers.ts
@@ -99,10 +99,11 @@ export const formValuesToCreateProductMapper = (values, viewType) => {
 }
 
 export const formValuesToUpdateProductMapper = (values) => {
+  console.log(values)
   return {
     title: values.title,
     handle: values.handle,
-    status: values.status || "published",
+    status: values.status,
     description: values.description,
     thumbnail: values.images.length
       ? values.images[values.thumbnail]


### PR DESCRIPTION
**What**
- remove default to "published" from update mapper in products domain