### PR TITLE
Fix: refund amount on return

### DIFF
--- a/src/components/organisms/rma-select-product-table/index.tsx
+++ b/src/components/organisms/rma-select-product-table/index.tsx
@@ -217,7 +217,7 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
               {checked && !isSwapOrClaim && (
                 <Table.Row className="last:border-b-0 hover:bg-grey-0">
                   <Table.Cell></Table.Cell>
-                  <Table.Cell colspan={2}>
+                  <Table.Cell colSpan={2}>
                     <div className="max-w-[470px] truncate">
                       {toReturn[item.id]?.reason && (
                         <span className="inter-small-regular text-grey-40">
@@ -242,7 +242,7 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
                       )}
                     </div>
                   </Table.Cell>
-                  <Table.Cell colspan={2}>
+                  <Table.Cell colSpan={2}>
                     <div className="flex w-full justify-end mb-small">
                       <Button
                         onClick={() =>

--- a/src/components/organisms/rma-select-product-table/index.tsx
+++ b/src/components/organisms/rma-select-product-table/index.tsx
@@ -214,7 +214,7 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
                   {order.currency_code.toUpperCase()}
                 </Table.Cell>
               </Table.Row>
-              {checked && (
+              {checked && !isSwapOrClaim && (
                 <Table.Row className="last:border-b-0 hover:bg-grey-0">
                   <Table.Cell></Table.Cell>
                   <Table.Cell colspan={2}>
@@ -242,32 +242,30 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
                       )}
                     </div>
                   </Table.Cell>
-                  {!isSwapOrClaim && (
-                    <Table.Cell colspan={2}>
-                      <div className="flex w-full justify-end mb-small">
-                        <Button
-                          onClick={() =>
-                            push(
-                              ReturnReasonScreen(
-                                pop,
-                                toReturn[item.id]?.reason,
-                                toReturn[item.id]?.note,
-                                customReturnOptions,
-                                imagesOnReturns,
-                                (reason, note, files) =>
-                                  setReturnReason(reason, note, files, item.id)
-                              )
+                  <Table.Cell colspan={2}>
+                    <div className="flex w-full justify-end mb-small">
+                      <Button
+                        onClick={() =>
+                          push(
+                            ReturnReasonScreen(
+                              pop,
+                              toReturn[item.id]?.reason,
+                              toReturn[item.id]?.note,
+                              customReturnOptions,
+                              imagesOnReturns,
+                              (reason, note, files) =>
+                                setReturnReason(reason, note, files, item.id)
                             )
-                          }
-                          variant="ghost"
-                          size="small"
-                          className="border border-grey-20"
-                        >
-                          Select Reason
-                        </Button>
-                      </div>
-                    </Table.Cell>
-                  )}
+                          )
+                        }
+                        variant="ghost"
+                        size="small"
+                        className="border border-grey-20"
+                      >
+                        Select Reason
+                      </Button>
+                    </div>
+                  </Table.Cell>
                 </Table.Row>
               )}
             </>

--- a/src/components/organisms/rma-select-receive-product-table/index.tsx
+++ b/src/components/organisms/rma-select-receive-product-table/index.tsx
@@ -1,3 +1,4 @@
+import { LineItem, Order } from "@medusajs/medusa"
 import clsx from "clsx"
 import React from "react"
 import { formatAmountWithSymbol } from "../../../utils/prices"
@@ -6,19 +7,19 @@ import MinusIcon from "../../fundamentals/icons/minus-icon"
 import PlusIcon from "../../fundamentals/icons/plus-icon"
 import Table from "../../molecules/table"
 
+type toReturnType = Record<string, { quantity: number }>
+
 type RMASelectProductTableProps = {
-  order: any
-  allItems: any[]
-  toReturn: any
+  order: Order
+  allItems: LineItem[]
+  toReturn: toReturnType
   setToReturn: (items: any) => void
-  imagesOnReturns?: any
 }
 
 const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
   order,
   allItems,
   toReturn,
-  imagesOnReturns = false,
   setToReturn,
 }) => {
   const handleQuantity = (change, item) => {
@@ -50,9 +51,6 @@ const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
       delete newReturns[id]
     } else {
       newReturns[id] = {
-        images: imagesOnReturns ? [] : null,
-        reason: null,
-        note: "",
         quantity: item.quantity,
       }
     }

--- a/src/components/organisms/rma-select-receive-product-table/index.tsx
+++ b/src/components/organisms/rma-select-receive-product-table/index.tsx
@@ -132,9 +132,6 @@ const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
                   </div>
                 </div>
               </Table.Cell>
-              {/* <Table.Cell className="text-right w-32 pr-8">
-                <span className="text-grey-40">{item.quantity}</span>
-              </Table.Cell> */}
               <Table.Cell className="text-right w-32 pr-8">
                 {item.id in toReturn ? (
                   <div className="flex w-full text-right justify-end text-grey-50 ">
@@ -155,9 +152,7 @@ const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
                     </span>
                   </div>
                 ) : (
-                  <span className="text-grey-40">
-                    {item.quantity - item.returned_quantity}
-                  </span>
+                  <span className="text-grey-40">{item.quantity}</span>
                 )}
               </Table.Cell>
               <Table.Cell className="text-right">

--- a/src/components/organisms/rma-select-receive-product-table/index.tsx
+++ b/src/components/organisms/rma-select-receive-product-table/index.tsx
@@ -11,7 +11,7 @@ type toReturnType = Record<string, { quantity: number }>
 
 type RMASelectProductTableProps = {
   order: Order
-  allItems: LineItem[]
+  allItems: (LineItem | null)[]
   toReturn: toReturnType
   setToReturn: (items: any) => void
 }
@@ -82,10 +82,10 @@ const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
       </Table.HeadRow>
       <Table.Body>
         {allItems.map((item) => {
-          console.log(item)
           // Only show items that have not been returned,
           // and aren't canceled
           if (
+            !item ||
             item.returned_quantity === item.quantity ||
             isLineItemCanceled(item)
           ) {

--- a/src/components/organisms/rma-select-receive-product-table/index.tsx
+++ b/src/components/organisms/rma-select-receive-product-table/index.tsx
@@ -24,8 +24,7 @@ const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
 }) => {
   const handleQuantity = (change, item) => {
     if (
-      (item.quantity - item.returned_quantity === toReturn[item.id].quantity &&
-        change > 0) ||
+      (item.quantity === toReturn[item.id].quantity && change > 0) ||
       (toReturn[item.id].quantity === 1 && change < 0)
     ) {
       return

--- a/src/components/organisms/rma-select-receive-product-table/index.tsx
+++ b/src/components/organisms/rma-select-receive-product-table/index.tsx
@@ -1,0 +1,135 @@
+import clsx from "clsx"
+import React from "react"
+import { formatAmountWithSymbol } from "../../../utils/prices"
+import CheckIcon from "../../fundamentals/icons/check-icon"
+import Table from "../../molecules/table"
+
+type RMASelectProductTableProps = {
+  order: any
+  allItems: any[]
+  toReturn: any
+  setToReturn: (items: any) => void
+  imagesOnReturns?: any
+}
+
+const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
+  order,
+  allItems,
+  toReturn,
+  imagesOnReturns = false,
+  setToReturn,
+}) => {
+  const handleReturnToggle = (item) => {
+    const id = item.id
+
+    const newReturns = { ...toReturn }
+
+    if (id in toReturn) {
+      delete newReturns[id]
+    } else {
+      newReturns[id] = {
+        images: imagesOnReturns ? [] : null,
+        reason: null,
+        note: "",
+        quantity: item.quantity,
+      }
+    }
+
+    setToReturn(newReturns)
+  }
+
+  const isLineItemCanceled = (item) => {
+    const { swap_id, claim_order_id } = item
+    const travFind = (col, id) =>
+      col.filter((f) => f.id == id && f.canceled_at).length > 0
+
+    if (swap_id) {
+      return travFind(order.swaps, swap_id)
+    }
+    if (claim_order_id) {
+      return travFind(order.claims, claim_order_id)
+    }
+    return false
+  }
+
+  return (
+    <Table>
+      <Table.HeadRow className="text-grey-50 inter-small-semibold">
+        <Table.HeadCell colSpan={2}>Product Details</Table.HeadCell>
+        <Table.HeadCell className="text-right pr-8">Quantity</Table.HeadCell>
+        <Table.HeadCell className="text-right">Refundable</Table.HeadCell>
+        <Table.HeadCell></Table.HeadCell>
+      </Table.HeadRow>
+      <Table.Body>
+        {allItems.map((item) => {
+          console.log(item)
+          // Only show items that have not been returned,
+          // and aren't canceled
+          if (
+            item.returned_quantity === item.quantity ||
+            isLineItemCanceled(item)
+          ) {
+            return
+          }
+          const checked = item.id in toReturn
+          return (
+            <Table.Row className={clsx("border-b-grey-0 hover:bg-grey-0")}>
+              <Table.Cell>
+                <div className="items-center ml-1 h-full flex">
+                  <div
+                    onClick={() => handleReturnToggle(item)}
+                    className={`mr-4 w-5 h-5 flex justify-center text-grey-0 border-grey-30 border cursor-pointer rounded-base ${
+                      checked && "bg-violet-60"
+                    }`}
+                  >
+                    <span className="self-center">
+                      {checked && <CheckIcon size={16} />}
+                    </span>
+                  </div>
+
+                  <input
+                    className="hidden"
+                    checked={checked}
+                    tabIndex={-1}
+                    onChange={() => handleReturnToggle(item)}
+                    type="checkbox"
+                  />
+                </div>
+              </Table.Cell>
+              <Table.Cell>
+                <div className="min-w-[240px] flex py-2">
+                  <div className="w-[30px] h-[40px] ">
+                    <img
+                      className="h-full w-full object-cover rounded"
+                      src={item.thumbnail}
+                    />
+                  </div>
+                  <div className="inter-small-regular text-grey-50 flex flex-col ml-4">
+                    <span>
+                      <span className="text-grey-90">{item.title}</span>
+                    </span>
+                    <span>{item?.variant?.title || ""}</span>
+                  </div>
+                </div>
+              </Table.Cell>
+              <Table.Cell className="text-right w-32 pr-8">
+                <span className="text-grey-40">{item.quantity}</span>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                {formatAmountWithSymbol({
+                  currency: order.currency_code,
+                  amount: item.quantity * item.unit_price,
+                })}
+              </Table.Cell>
+              <Table.Cell className="text-right text-grey-40 pr-1">
+                {order.currency_code.toUpperCase()}
+              </Table.Cell>
+            </Table.Row>
+          )
+        })}
+      </Table.Body>
+    </Table>
+  )
+}
+
+export default RMASelectReturnProductTable

--- a/src/components/organisms/rma-select-receive-product-table/index.tsx
+++ b/src/components/organisms/rma-select-receive-product-table/index.tsx
@@ -2,6 +2,8 @@ import clsx from "clsx"
 import React from "react"
 import { formatAmountWithSymbol } from "../../../utils/prices"
 import CheckIcon from "../../fundamentals/icons/check-icon"
+import MinusIcon from "../../fundamentals/icons/minus-icon"
+import PlusIcon from "../../fundamentals/icons/plus-icon"
 import Table from "../../molecules/table"
 
 type RMASelectProductTableProps = {
@@ -19,6 +21,26 @@ const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
   imagesOnReturns = false,
   setToReturn,
 }) => {
+  const handleQuantity = (change, item) => {
+    if (
+      (item.quantity - item.returned_quantity === toReturn[item.id].quantity &&
+        change > 0) ||
+      (toReturn[item.id].quantity === 1 && change < 0)
+    ) {
+      return
+    }
+
+    const newReturns = {
+      ...toReturn,
+      [item.id]: {
+        ...toReturn[item.id],
+        quantity: (toReturn[item.id]?.quantity || 0) + change,
+      },
+    }
+
+    setToReturn(newReturns)
+  }
+
   const handleReturnToggle = (item) => {
     const id = item.id
 
@@ -112,8 +134,33 @@ const RMASelectReturnProductTable: React.FC<RMASelectProductTableProps> = ({
                   </div>
                 </div>
               </Table.Cell>
-              <Table.Cell className="text-right w-32 pr-8">
+              {/* <Table.Cell className="text-right w-32 pr-8">
                 <span className="text-grey-40">{item.quantity}</span>
+              </Table.Cell> */}
+              <Table.Cell className="text-right w-32 pr-8">
+                {item.id in toReturn ? (
+                  <div className="flex w-full text-right justify-end text-grey-50 ">
+                    <span
+                      onClick={() => handleQuantity(-1, item)}
+                      className="w-5 h-5 flex items-center justify-center rounded cursor-pointer hover:bg-grey-20 mr-2"
+                    >
+                      <MinusIcon size={16} />
+                    </span>
+                    <span>{toReturn[item.id].quantity || ""}</span>
+                    <span
+                      onClick={() => handleQuantity(1, item)}
+                      className={clsx(
+                        "w-5 h-5 flex items-center justify-center rounded cursor-pointer hover:bg-grey-20 ml-2"
+                      )}
+                    >
+                      <PlusIcon size={16} />
+                    </span>
+                  </div>
+                ) : (
+                  <span className="text-grey-40">
+                    {item.quantity - item.returned_quantity}
+                  </span>
+                )}
               </Table.Cell>
               <Table.Cell className="text-right">
                 {formatAmountWithSymbol({

--- a/src/domain/orders/details/returns/receive-menu.tsx
+++ b/src/domain/orders/details/returns/receive-menu.tsx
@@ -32,7 +32,7 @@ const ReceiveMenu: React.FC<ReceiveMenuProps> = ({
   const [refundAmount, setRefundAmount] = useState(0)
   const [toReturn, setToReturn] = useState({})
 
-  const allItems: (LineItem | null)[] = useMemo(() => {
+  const allItems: LineItem[] = useMemo(() => {
     return order.items
       .map((i: LineItem) => {
         const found = returnRequest.items.find(
@@ -48,7 +48,7 @@ const ReceiveMenu: React.FC<ReceiveMenuProps> = ({
           return null
         }
       })
-      .filter(Boolean)
+      .filter(Boolean) as LineItem[]
   }, [order])
 
   useEffect(() => {

--- a/src/domain/orders/details/returns/receive-menu.tsx
+++ b/src/domain/orders/details/returns/receive-menu.tsx
@@ -7,6 +7,7 @@ import CurrencyInput from "../../../../components/organisms/currency-input"
 import { getErrorMessage } from "../../../../utils/error-messages"
 import { displayAmount } from "../../../../utils/prices"
 import RMASelectReturnProductTable from "../../../../components/organisms/rma-select-receive-product-table"
+import useNotification from "../../../../hooks/use-notification"
 
 type ReceiveMenuProps = {
   order: Order
@@ -14,7 +15,6 @@ type ReceiveMenuProps = {
   onDismiss: () => void
   onReceiveSwap?: (payload: any) => Promise<void>
   onReceiveReturn?: (id: string, payload: any) => Promise<void>
-  notification: any
   refunded?: boolean
 }
 
@@ -24,7 +24,6 @@ const ReceiveMenu: React.FC<ReceiveMenuProps> = ({
   onReceiveReturn,
   onReceiveSwap,
   onDismiss,
-  notification,
   refunded,
 }) => {
   const [submitting, setSubmitting] = useState(false)
@@ -32,13 +31,14 @@ const ReceiveMenu: React.FC<ReceiveMenuProps> = ({
   const [refundAmount, setRefundAmount] = useState(0)
   const [toReturn, setToReturn] = useState({})
 
+  const notification = useNotification()
+
   const allItems: LineItem[] = useMemo(() => {
     return order.items
       .map((i: LineItem) => {
         const found = returnRequest.items.find(
           (ri: ReturnItem) => ri.item_id === i.id
         )
-
         if (found) {
           return {
             ...i,

--- a/src/domain/orders/details/returns/receive-menu.tsx
+++ b/src/domain/orders/details/returns/receive-menu.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect, useState } from "react"
-import { LineItem, Order, ReturnItem } from "@medusajs/medusa"
+import { LineItem, Order, Return, ReturnItem } from "@medusajs/medusa"
 import Button from "../../../../components/fundamentals/button"
 import EditIcon from "../../../../components/fundamentals/icons/edit-icon"
 import Modal from "../../../../components/molecules/modal"
@@ -10,7 +10,7 @@ import RMASelectReturnProductTable from "../../../../components/organisms/rma-se
 
 type ReceiveMenuProps = {
   order: Order
-  returnRequest: any
+  returnRequest: Return
   onDismiss: () => void
   onReceiveSwap?: (payload: any) => Promise<void>
   onReceiveReturn?: (id: string, payload: any) => Promise<void>


### PR DESCRIPTION
**What**
- Fix bug where receiving a partial return would refund the amount of entire quantity of products (i.e. receiving a return of 1/2 items would refund 2/2 items) 
- remove additional line for return reason which added padding when a line was selected in a swap or claim

**Why**
- to ensure that refunds are calculated correctly

**How**
- adjust how the total for the return is calculated
- Add a table specifically for receiving returns where reasons cannot be set (since they are set when registering)