### PR TITLE
Fix: Notifications when cancelling exchanges

### DIFF
--- a/src/components/molecules/timeline-events/exchange.tsx
+++ b/src/components/molecules/timeline-events/exchange.tsx
@@ -238,7 +238,7 @@ const Exchange: React.FC<ExchangeProps> = ({ event, refetch }) => {
       {showCancel && (
         <DeletePrompt
           handleClose={() => setShowCancel(!showCancel)}
-          onDelete={async () => handleCancelExchange()}
+          onDelete={handleCancelExchange}
           confirmText="Yes, cancel"
           heading="Cancel exchange"
           text="Are you sure you want to cancel this exchange?"
@@ -248,7 +248,7 @@ const Exchange: React.FC<ExchangeProps> = ({ event, refetch }) => {
       {showCancelReturn && (
         <DeletePrompt
           handleClose={() => setShowCancelReturn(!showCancelReturn)}
-          onDelete={async () => handleCancelReturn()}
+          onDelete={handleCancelReturn}
           confirmText="Yes, cancel"
           heading="Cancel return"
           text="Are you sure you want to cancel this return?"

--- a/src/components/molecules/timeline-events/exchange.tsx
+++ b/src/components/molecules/timeline-events/exchange.tsx
@@ -112,13 +112,13 @@ const Exchange: React.FC<ExchangeProps> = ({ event, refetch }) => {
     event.exchangeCartId
   )
 
-  const handleCancelExchange = () => {
-    cancelExchange.mutate(event.id)
+  const handleCancelExchange = async () => {
+    await cancelExchange.mutateAsync(event.id)
     refetch()
   }
 
-  const handleCancelReturn = () => {
-    cancelReturn.mutate()
+  const handleCancelReturn = async () => {
+    await cancelReturn.mutateAsync()
     refetch()
   }
 
@@ -163,7 +163,7 @@ const Exchange: React.FC<ExchangeProps> = ({ event, refetch }) => {
     actions.push({
       label: "Cancel return",
       icon: <TruckIcon size={20} />,
-      onClick: handleCancelReturn,
+      onClick: () => setShowCancelReturn(!showCancelReturn),
     })
   }
 
@@ -182,7 +182,7 @@ const Exchange: React.FC<ExchangeProps> = ({ event, refetch }) => {
   }
 
   const args = {
-    title: event.canceledAt ? "Exchange Canceled" : "Exchange Requested",
+    title: event.canceledAt ? "Exchange Cancelled" : "Exchange Requested",
     icon: event.canceledAt ? (
       <CancelIcon size={20} />
     ) : (
@@ -242,7 +242,7 @@ const Exchange: React.FC<ExchangeProps> = ({ event, refetch }) => {
           confirmText="Yes, cancel"
           heading="Cancel exchange"
           text="Are you sure you want to cancel this exchange?"
-          successText="Exchange canceled"
+          successText="Exchange cancelled"
         />
       )}
       {showCancelReturn && (
@@ -252,7 +252,7 @@ const Exchange: React.FC<ExchangeProps> = ({ event, refetch }) => {
           confirmText="Yes, cancel"
           heading="Cancel return"
           text="Are you sure you want to cancel this return?"
-          successText="Return canceled"
+          successText="Return cancelled"
         />
       )}
       {showReceiveReturn && (


### PR DESCRIPTION
**What**
- notification handling when cancelling returns on exchanges and exchanges 

**How**
- make handling methods async and use the delete prompts for cancelling exchanges and returns

**Why**
- previously when cancelling an exchange without first cancelling the return no error was shown and nothing was cancelled