### PR TITLE
Fix: Refresh team sidebar when personal information for a user is updated

### DIFF
--- a/src/components/organisms/sidebar-team/index.tsx
+++ b/src/components/organisms/sidebar-team/index.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import clsx from "clsx"
 import SidebarTeamMember from "../../molecules/sidebar-team-member"
 import PlusIcon from "../../fundamentals/icons/plus-icon"
 import ArrowLeftIcon from "../../fundamentals/icons/arrow-left-icon"
 import ArrowRightIcon from "../../fundamentals/icons/arrow-right-icon"
 import InviteModal from "../invite-modal"
+import { useAdminUsers } from "medusa-react"
+import { User } from "@medusajs/medusa"
 
 type PaginationArrowsProps = {
   currentPage: number
@@ -13,17 +15,9 @@ type PaginationArrowsProps = {
   handlePreviousPage: () => void
 }
 
-type SidebarTeamUser = {
-  id: string
-  email: string
-  first_name?: string
-  last_name?: string
-  img?: string
-}
+type UserType = Omit<User, "password_hash">
 
-type SidebarTeamProps = {
-  users: SidebarTeamUser[]
-}
+const PAGE_SIZE = 6
 
 const getColor = (index: number): string => {
   const colors = [
@@ -76,10 +70,23 @@ const PaginationArrows: React.FC<PaginationArrowsProps> = ({
   )
 }
 
-const SidebarTeam: React.FC<SidebarTeamProps> = ({ users }) => {
+const SidebarTeam: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [currentPage, setCurrentPage] = useState(0)
-  const paginatedUsers = []
+  const [paginatedUsers, setPaginatedUsers] = useState<UserType[][]>([])
+
+  const { users, isLoading } = useAdminUsers()
+
+  useEffect(() => {
+    if (!isLoading && users?.length) {
+      const paginationResult: UserType[][] = []
+      for (let i = 0; i < users.length; i += PAGE_SIZE) {
+        paginationResult.push(users.slice(i, i + PAGE_SIZE))
+      }
+
+      setPaginatedUsers(paginationResult)
+    }
+  }, [isLoading, users])
 
   const previousPage = () => {
     if (currentPage !== 0) {
@@ -91,11 +98,6 @@ const SidebarTeam: React.FC<SidebarTeamProps> = ({ users }) => {
     if (paginatedUsers.length !== currentPage + 1) {
       setCurrentPage(currentPage + 1)
     }
-  }
-
-  const pageSize = 6
-  for (let i = 0; i < users.length; i += pageSize) {
-    paginatedUsers.push(users.slice(i, i + pageSize))
   }
 
   return (

--- a/src/components/organisms/sidebar/index.tsx
+++ b/src/components/organisms/sidebar/index.tsx
@@ -1,12 +1,10 @@
-import { useAdminStore } from "medusa-react"
-import React, { useEffect, useState } from "react"
-import Medusa from "../../../services/api"
+import { useAdminStore, useAdminUsers } from "medusa-react"
+import React, { useState } from "react"
 import CashIcon from "../../fundamentals/icons/cash-icon"
 import CustomerIcon from "../../fundamentals/icons/customer-icon"
 import DollarSignIcon from "../../fundamentals/icons/dollar-sign-icon"
 import GearIcon from "../../fundamentals/icons/gear-icon"
 import GiftIcon from "../../fundamentals/icons/gift-icon"
-import PercentIcon from "../../fundamentals/icons/percent-icon"
 import SaleIcon from "../../fundamentals/icons/sale-icon"
 import TagIcon from "../../fundamentals/icons/tag-icon"
 import SidebarCompanyLogo from "../../molecules/sidebar-company-logo"
@@ -17,19 +15,8 @@ const ICON_SIZE = 18
 
 const Sidebar: React.FC = () => {
   const [currentlyOpen, setCurrentlyOpen] = useState(-1)
-  const [users, setUsers] = useState([])
 
   const { store } = useAdminStore()
-
-  const fetchUsers = async () => {
-    Medusa.users.list().then(({ data }) => {
-      setUsers(data.users)
-    })
-  }
-
-  useEffect(() => {
-    fetchUsers()
-  }, [])
 
   const triggerHandler = () => {
     const id = triggerHandler.id++
@@ -93,7 +80,7 @@ const Sidebar: React.FC = () => {
         </div>
 
         <div className="font-semibold mt-5 flex flex-col text-small">
-          <SidebarTeam users={users} />
+          <SidebarTeam />
         </div>
       </div>
     </div>

--- a/src/context/account.js
+++ b/src/context/account.js
@@ -1,5 +1,6 @@
 import React, { useReducer } from "react"
 import Medusa from "../services/api"
+import { queryClient } from "../services/config"
 
 export const defaultAccountContext = {
   isLoggedIn: false,
@@ -60,6 +61,7 @@ export const AccountProvider = ({ children }) => {
 
         handleUpdateUser: (id, user) => {
           return Medusa.users.update(id, user).then(({ data }) => {
+            queryClient.invalidateQueries("admin_users")
             dispatch({ type: "updateUser", payload: data.user })
           })
         },

--- a/src/context/account.js
+++ b/src/context/account.js
@@ -1,3 +1,4 @@
+import { adminUserKeys } from "medusa-react"
 import React, { useReducer } from "react"
 import Medusa from "../services/api"
 import { queryClient } from "../services/config"
@@ -61,7 +62,7 @@ export const AccountProvider = ({ children }) => {
 
         handleUpdateUser: (id, user) => {
           return Medusa.users.update(id, user).then(({ data }) => {
-            queryClient.invalidateQueries("admin_users")
+            queryClient.invalidateQueries(adminUserKeys.all)
             dispatch({ type: "updateUser", payload: data.user })
           })
         },


### PR DESCRIPTION
**What**
- refresh team sidebar when updating personal information

**Why**
- When updating first name with a different first letter the sidebar did not previously update the avatar to reflect the change

**How**
- refactor sidebar and team sidebar s.t. users query is run in team sidebar query
