### PR TITLE
fix: create variant bugs

### DIFF
--- a/src/components/molecules/table/index.tsx
+++ b/src/components/molecules/table/index.tsx
@@ -28,7 +28,7 @@ type TablePaginationProps = React.HTMLAttributes<HTMLDivElement> & {
   hasPrev: boolean
 }
 
-type TableCellProps = React.HTMLAttributes<HTMLTableCellElement> & {
+type TableCellProps = React.TdHTMLAttributes<HTMLTableCellElement> & {
   linkTo?: string
   name?: string
 }
@@ -55,7 +55,7 @@ type TableElement<T> = React.ForwardRefExoticComponent<T> &
 type TableType = {
   Head: TableElement<React.HTMLAttributes<HTMLTableElement>>
   HeadRow: TableElement<React.HTMLAttributes<HTMLTableRowElement>>
-  HeadCell: TableElement<React.HTMLAttributes<HTMLTableCellElement>>
+  HeadCell: TableElement<React.ThHTMLAttributes<HTMLTableCellElement>>
   SortingHeadCell: TableElement<SortingHeadCellProps>
   Body: TableElement<React.HTMLAttributes<HTMLTableSectionElement>>
   Row: TableElement<TableRowProps>
@@ -158,7 +158,7 @@ Table.HeadCell = React.forwardRef(
       className,
       children,
       ...props
-    }: React.HTMLAttributes<HTMLTableCellElement> & { colSpan?: number },
+    }: React.ThHTMLAttributes<HTMLTableCellElement> & { colSpan?: number },
     ref
   ) => (
     <th ref={ref} className={clsx("text-left h-[40px]", className)} {...props}>

--- a/src/components/organisms/rma-select-product-table/index.tsx
+++ b/src/components/organisms/rma-select-product-table/index.tsx
@@ -1,3 +1,4 @@
+import { Order } from "@medusajs/medusa"
 import clsx from "clsx"
 import React, { useContext } from "react"
 import RMAReturnReasonSubModal from "../../../domain/orders/details/rma-sub-modals/return-reasons"
@@ -11,7 +12,7 @@ import { LayeredModalContext } from "../../molecules/modal/layered-modal"
 import Table from "../../molecules/table"
 
 type RMASelectProductTableProps = {
-  order: any
+  order: Order
   allItems: any[]
   toReturn: any
   setToReturn: (items: any) => void
@@ -30,6 +31,8 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
   isSwapOrClaim = false,
 }) => {
   const { push, pop } = useContext(LayeredModalContext)
+
+  console.log(allItems, toReturn)
 
   const handleQuantity = (change, item) => {
     if (
@@ -207,7 +210,8 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
                 <Table.Cell className="text-right">
                   {formatAmountWithSymbol({
                     currency: order.currency_code,
-                    amount: item.refundable,
+                    amount:
+                      (item.refundable / item.shipped_quantity) * item.quantity,
                   })}
                 </Table.Cell>
                 <Table.Cell className="text-right text-grey-40 pr-1">
@@ -217,7 +221,7 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
               {checked && (
                 <Table.Row className="last:border-b-0 hover:bg-grey-0">
                   <Table.Cell></Table.Cell>
-                  <Table.Cell colspan={2}>
+                  <Table.Cell colSpan={2}>
                     <div className="max-w-[470px] truncate">
                       {toReturn[item.id]?.reason && (
                         <span className="inter-small-regular text-grey-40">
@@ -243,7 +247,7 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
                     </div>
                   </Table.Cell>
                   {!isSwapOrClaim && (
-                    <Table.Cell colspan={2}>
+                    <Table.Cell colSpan={2}>
                       <div className="flex w-full justify-end mb-small">
                         <Button
                           onClick={() =>

--- a/src/domain/orders/details/returns/receive-menu.tsx
+++ b/src/domain/orders/details/returns/receive-menu.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useEffect, useState } from "react"
 import { LineItem, ReturnItem } from "@medusajs/medusa"
+import React, { useEffect, useMemo, useState } from "react"
 import Button from "../../../../components/fundamentals/button"
 import EditIcon from "../../../../components/fundamentals/icons/edit-icon"
 import Modal from "../../../../components/molecules/modal"
@@ -36,21 +36,25 @@ const ReceiveMenu: React.FC<ReceiveMenuProps> = ({
   const [quantities, setQuantities] = useState({})
 
   const allItems: LineItem[] = useMemo(() => {
-    return order.items.map((i: LineItem) => {
-      const found = returnRequest.items.find(
-        (ri: ReturnItem) => ri.item_id === i.id
-      )
+    return order.items
+      .map((i: LineItem) => {
+        const found = returnRequest.items.find(
+          (ri: ReturnItem) => ri.item_id === i.id
+        )
 
-      if (found) {
-        return {
-          ...i,
-          quantity: found.quantity,
+        if (found) {
+          return {
+            ...i,
+            quantity: found.quantity,
+          }
+        } else {
+          return null
         }
-      } else {
-        return null
-      }
-    }).filter(Boolean)
+      })
+      .filter(Boolean)
   }, [order])
+
+  console.log(returnRequest)
 
   useEffect(() => {
     const returns = []
@@ -81,7 +85,9 @@ const ReceiveMenu: React.FC<ReceiveMenuProps> = ({
 
     const total =
       items.reduce((acc, next) => {
-        return acc + ((next.refundable || 0) / next.quantity) * quantities[next.id]
+        return (
+          acc + ((next.refundable || 0) / next.quantity) * quantities[next.id]
+        )
       }, 0) -
       ((returnRequest.shipping_method &&
         returnRequest.shipping_method.price * (1 + order.tax_rate / 100)) ||

--- a/src/domain/products/details/variants/variant-editor.tsx
+++ b/src/domain/products/details/variants/variant-editor.tsx
@@ -79,6 +79,19 @@ const VariantEditor = ({
   }, [variant, store])
 
   const handleSave = (data) => {
+    if (!data.prices) {
+      const element = document.getElementById("add-price")
+      if (element) {
+        element.focus()
+      }
+
+      return
+    }
+
+    if (!data.title) {
+      data.title = data.options.map((o) => o.value).join(" / ")
+    }
+
     data.prices = data.prices.map(({ price: { currency_code, amount } }) => ({
       currency_code,
       amount: Math.round(amount),
@@ -131,6 +144,7 @@ const VariantEditor = ({
                   <Input
                     ref={register({ required: true })}
                     name={`options[${index}].value`}
+                    required={true}
                     label={field.title}
                     defaultValue={field.value}
                   />
@@ -147,9 +161,10 @@ const VariantEditor = ({
           <div className="mb-8">
             <label
               tabIndex={0}
-              className="inter-base-semibold mb-4 flex items-center gap-xsmall"
+              className="inter-base-semibold mb-4 flex items-center"
             >
               {"Prices"}
+              <span className="text-rose-50 mr-xsmall">*</span>
               <IconTooltip content={"Variant prices"} />
             </label>
 
@@ -208,6 +223,7 @@ const VariantEditor = ({
               onClick={appendPrice}
               size="small"
               variant="ghost"
+              id="add-price"
               disabled={availableCurrencies?.length === 0}
             >
               <PlusIcon size={20} /> Add a price

--- a/src/domain/products/details/variants/variant-editor.tsx
+++ b/src/domain/products/details/variants/variant-editor.tsx
@@ -48,11 +48,19 @@ const VariantEditor = ({
     appendPrice,
     deletePrice,
     availableCurrencies,
-  } = usePricesFieldArray(store?.currencies.map((c) => c.code) || [], {
-    control,
-    name: "prices",
-    keyName: "indexId",
-  })
+  } = usePricesFieldArray(
+    store?.currencies.map((c) => c.code) || [],
+    {
+      control,
+      name: "prices",
+      keyName: "indexId",
+    },
+    {
+      defaultAmount: 1000,
+      defaultCurrencyCode:
+        store?.default_currency.code || store?.currencies[0].code || "usd",
+    }
+  )
 
   const { fields } = useFieldArray({
     control,

--- a/src/domain/products/product-form/sections/variants.tsx
+++ b/src/domain/products/product-form/sections/variants.tsx
@@ -95,7 +95,11 @@ const Variants = ({ isEdit, product }) => {
   }
 
   const handleAddVariant = (data) => {
-    createVariant.mutate(data, {
+    const newVariant = {
+      ...data,
+      inventory_quantity: data.inventory_quantity || 0,
+    }
+    createVariant.mutate(newVariant, {
       onSuccess: () => {
         notification("Success", "Successfully added a variant", "success")
         setShowAddVariantModal(false)


### PR DESCRIPTION
**What**

See #546 for description of errors that are fixed.

**How**

- If no title is provided in the form, create a title from the joining the option values. Same way as we do it when creating a new product w/ variants.
- If not inventory quantity is provided add `inventory_quantity: 0` to the request.
- Add a required `*` to option inputs to signify that they are required to fill out.
- If no prices are entered, focus the `Add price` button, also add required `*` to the Prices label to signify that it is required to add a price.