### PR TITLE
fix: bugs related to creating variant

### DIFF
--- a/src/domain/products/details/variants/variant-editor.tsx
+++ b/src/domain/products/details/variants/variant-editor.tsx
@@ -12,6 +12,7 @@ import Select from "../../../../components/molecules/select"
 import CurrencyInput from "../../../../components/organisms/currency-input"
 import { convertEmptyStringToNull } from "../../../../utils/convert-empty-string-to-null"
 import { countries as countryData } from "../../../../utils/countries"
+import { focusByName } from "../../../../utils/focus-by-name"
 import usePricesFieldArray from "../../product-form/form/usePricesFieldArray"
 
 const defaultVariant = {
@@ -80,11 +81,7 @@ const VariantEditor = ({
 
   const handleSave = (data) => {
     if (!data.prices) {
-      const element = document.getElementById("add-price")
-      if (element) {
-        element.focus()
-      }
-
+      focusByName("add-price")
       return
     }
 
@@ -223,7 +220,7 @@ const VariantEditor = ({
               onClick={appendPrice}
               size="small"
               variant="ghost"
-              id="add-price"
+              name="add-price"
               disabled={availableCurrencies?.length === 0}
             >
               <PlusIcon size={20} /> Add a price

--- a/src/domain/products/details/variants/variant-editor.tsx
+++ b/src/domain/products/details/variants/variant-editor.tsx
@@ -79,6 +79,19 @@ const VariantEditor = ({
   }, [variant, store])
 
   const handleSave = (data) => {
+    if (!data.prices) {
+      const element = document.getElementById("add-price")
+      if (element) {
+        element.focus()
+      }
+
+      return
+    }
+
+    if (!data.title) {
+      data.title = data.options.map((o) => o.value).join(" / ")
+    }
+
     data.prices = data.prices.map(({ price: { currency_code, amount } }) => ({
       currency_code,
       amount: Math.round(amount),
@@ -131,6 +144,7 @@ const VariantEditor = ({
                   <Input
                     ref={register({ required: true })}
                     name={`options[${index}].value`}
+                    required={true}
                     label={field.title}
                     defaultValue={field.value}
                   />
@@ -147,9 +161,10 @@ const VariantEditor = ({
           <div className="mb-8">
             <label
               tabIndex={0}
-              className="inter-base-semibold mb-4 flex items-center gap-xsmall"
+              className="inter-base-semibold mb-4 flex items-center"
             >
               {"Prices"}
+              <span className="text-rose-50 mr-xsmall">*</span>
               <IconTooltip content={"Variant prices"} />
             </label>
 
@@ -208,6 +223,7 @@ const VariantEditor = ({
               onClick={appendPrice}
               size="small"
               variant="ghost"
+              id="add-price"
               disabled={availableCurrencies?.length === 0}
             >
               <PlusIcon size={20} /> Add a price

--- a/src/domain/products/product-form/sections/variants.tsx
+++ b/src/domain/products/product-form/sections/variants.tsx
@@ -95,7 +95,12 @@ const Variants = ({ isEdit, product }) => {
   }
 
   const handleAddVariant = (data) => {
-    createVariant.mutate(data, {
+    const newVariant = {
+      ...data,
+      inventory_quantity: data.inventory_quantity || 0,
+    }
+
+    createVariant.mutate(newVariant, {
       onSuccess: () => {
         notification("Success", "Successfully added a variant", "success")
         setShowAddVariantModal(false)


### PR DESCRIPTION
**What**

See #546 for description of errors that are fixed.

**How**

- If no title is provided in the form, create a title from the joining the option values. Same way as we do it when creating a new product w/ variants.
- If not inventory quantity is provided add `inventory_quantity: 0` to the request.
- Add a required `*` to option inputs to signify that they are required to fill out.
- If no prices are entered, focus the `Add price` button, also add required `*` to the Prices label to signify that it is required to add a price.