### PR TITLE
fix: fixed types of Table component allowing colSpan prop to work as intended

### DIFF
--- a/src/components/molecules/table/index.tsx
+++ b/src/components/molecules/table/index.tsx
@@ -28,7 +28,7 @@ type TablePaginationProps = React.HTMLAttributes<HTMLDivElement> & {
   hasPrev: boolean
 }
 
-type TableCellProps = React.HTMLAttributes<HTMLTableCellElement> & {
+type TableCellProps = React.TdHTMLAttributes<HTMLTableCellElement> & {
   linkTo?: string
   name?: string
 }
@@ -53,9 +53,9 @@ type TableElement<T> = React.ForwardRefExoticComponent<T> &
   React.RefAttributes<unknown>
 
 type TableType = {
-  Head: TableElement<React.HTMLAttributes<HTMLTableElement>>
+  Head: TableElement<React.HTMLAttributes<HTMLTableSectionElement>>
   HeadRow: TableElement<React.HTMLAttributes<HTMLTableRowElement>>
-  HeadCell: TableElement<React.HTMLAttributes<HTMLTableCellElement>>
+  HeadCell: TableElement<React.ThHTMLAttributes<HTMLTableCellElement>>
   SortingHeadCell: TableElement<SortingHeadCellProps>
   Body: TableElement<React.HTMLAttributes<HTMLTableSectionElement>>
   Row: TableElement<TableRowProps>
@@ -64,7 +64,7 @@ type TableType = {
     React.RefAttributes<unknown>
 } & TableElement<TableProps>
 
-const Table: TableType = React.forwardRef(
+const Table = React.forwardRef<HTMLTableElement, TableProps>(
   (
     {
       className,
@@ -77,7 +77,7 @@ const Table: TableType = React.forwardRef(
       filteringOptions,
       containerClassName,
       ...props
-    }: TableProps,
+    },
     ref
   ) => {
     if (enableSearch && !handleSearch) {
@@ -102,7 +102,7 @@ const Table: TableType = React.forwardRef(
                 autoFocus={immediateSearchFocus}
                 placeholder={searchPlaceholder}
                 searchValue={searchValue}
-                onSearch={handleSearch}
+                onSearch={handleSearch!}
               />
             )}
           </div>
@@ -117,57 +117,46 @@ const Table: TableType = React.forwardRef(
       </div>
     )
   }
-)
+) as TableType
 
-Table.Head = React.forwardRef(
-  (
-    { className, children, ...props }: React.HTMLAttributes<HTMLTableElement>,
-    ref
-  ) => (
-    <thead
-      ref={ref}
-      className={clsx(
-        "whitespace-nowrap inter-small-semibold text-grey-50 border-t border-b border-grey-20",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </thead>
-  )
-)
+Table.Head = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, children, ...props }, ref) => (
+  <thead
+    ref={ref}
+    className={clsx(
+      "whitespace-nowrap inter-small-semibold text-grey-50 border-t border-b border-grey-20",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </thead>
+))
 
-Table.HeadRow = React.forwardRef(
-  (
-    {
-      className,
-      children,
-      ...props
-    }: React.HTMLAttributes<HTMLTableRowElement>,
-    ref
-  ) => (
-    <tr ref={ref} className={clsx(className)} {...props}>
-      {children}
-    </tr>
-  )
-)
+Table.HeadRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, children, ...props }, ref) => (
+  <tr ref={ref} className={clsx(className)} {...props}>
+    {children}
+  </tr>
+))
 
-Table.HeadCell = React.forwardRef(
-  (
-    {
-      className,
-      children,
-      ...props
-    }: React.HTMLAttributes<HTMLTableCellElement> & { colSpan?: number },
-    ref
-  ) => (
-    <th ref={ref} className={clsx("text-left h-[40px]", className)} {...props}>
-      {children}
-    </th>
-  )
-)
+Table.HeadCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.HTMLAttributes<HTMLTableCellElement>
+>(({ className, children, ...props }, ref) => (
+  <th ref={ref} className={clsx("text-left h-[40px]", className)} {...props}>
+    {children}
+  </th>
+))
 
-Table.SortingHeadCell = React.forwardRef(
+Table.SortingHeadCell = React.forwardRef<
+  HTMLTableCellElement,
+  SortingHeadCellProps
+>(
   (
     {
       onSortClicked,
@@ -209,23 +198,17 @@ Table.SortingHeadCell = React.forwardRef(
   }
 )
 
-Table.Body = React.forwardRef(
-  (
-    {
-      className,
-      children,
-      ...props
-    }: React.HTMLAttributes<HTMLTableSectionElement>,
-    ref
-  ) => (
-    <tbody ref={ref} className={clsx(className)} {...props}>
-      {children}
-    </tbody>
-  )
-)
+Table.Body = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, children, ...props }, ref) => (
+  <tbody ref={ref} className={clsx(className)} {...props}>
+    {children}
+  </tbody>
+))
 
-Table.Cell = React.forwardRef(
-  ({ className, linkTo, children, ...props }: TableCellProps, ref) => (
+Table.Cell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
+  ({ className, linkTo, children, ...props }, ref) => (
     <td
       ref={ref}
       className={clsx("inter-small-regular h-[40px]", className)}
@@ -242,18 +225,8 @@ Table.Cell = React.forwardRef(
   )
 )
 
-Table.Row = React.forwardRef(
-  (
-    {
-      className,
-      actions,
-      children,
-      linkTo,
-      forceDropdown,
-      ...props
-    }: TableRowProps,
-    ref
-  ) => (
+Table.Row = React.forwardRef<HTMLTableRowElement, TableRowProps>(
+  ({ className, actions, children, linkTo, forceDropdown, ...props }, ref) => (
     <tr
       ref={ref}
       className={clsx(

--- a/src/components/molecules/timeline-events/claim/details.tsx
+++ b/src/components/molecules/timeline-events/claim/details.tsx
@@ -82,7 +82,7 @@ const ClaimDetails = ({ claim, order, onDismiss }) => {
                         </Table.Cell>
                       </Table.Row>
                       <Table.Row className="last:border-b-0 hover:bg-grey-0">
-                        <Table.Cell colspan={2}>
+                        <Table.Cell colSpan={2}>
                           <div className="max-w-[470px] truncate">
                             {claimItem.reason && (
                               <span className="inter-small-regular text-grey-40">
@@ -104,7 +104,7 @@ const ClaimDetails = ({ claim, order, onDismiss }) => {
                             )}
                           </div>
                         </Table.Cell>
-                        <Table.Cell colspan={2}>
+                        <Table.Cell colSpan={2}>
                           <div className="flex w-full justify-end">
                             <Button
                               onClick={() =>

--- a/src/components/organisms/rma-select-product-table/index.tsx
+++ b/src/components/organisms/rma-select-product-table/index.tsx
@@ -217,7 +217,7 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
               {checked && (
                 <Table.Row className="last:border-b-0 hover:bg-grey-0">
                   <Table.Cell></Table.Cell>
-                  <Table.Cell colspan={2}>
+                  <Table.Cell colSpan={2}>
                     <div className="max-w-[470px] truncate">
                       {toReturn[item.id]?.reason && (
                         <span className="inter-small-regular text-grey-40">
@@ -243,7 +243,7 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
                     </div>
                   </Table.Cell>
                   {!isSwapOrClaim && (
-                    <Table.Cell colspan={2}>
+                    <Table.Cell colSpan={2}>
                       <div className="flex w-full justify-end mb-small">
                         <Button
                           onClick={() =>


### PR DESCRIPTION
**What**

The `Table` element was incorrectly typed, which resulted in the `colSpan` prop being used wrong in some instances, and TS not detecting these errors.

This fixes the typing of the component and subcomponents, and fixes the wrong uses of `colSpan`. 