### PR TITLE
fix: don't apply region taxes to custom gift cards

### DIFF
--- a/src/domain/gift-cards/custom-giftcard.tsx
+++ b/src/domain/gift-cards/custom-giftcard.tsx
@@ -51,9 +51,7 @@ const CustomGiftcard: React.FC<CustomGiftcardProps> = ({ onDismiss }) => {
 
     const update = {
       region_id: selectedRegion.value.id,
-      value: Math.round(
-        giftCardAmount / (1 + selectedRegion.value.tax_rate / 100)
-      ),
+      value: Math.round(giftCardAmount),
       ...data,
     }
 


### PR DESCRIPTION
When I'm in the admin UI and want to create a custom gift card, it shouldn't remove balance from the number I just input. I would understand charging taxes in a purchase, but if a store owner wants to give a gift card to someone with a round number ,they shouldn't have to finagle with the admin UI to get a nice round number.

https://www.loom.com/share/b81cee853ffb48f88d8792bc87d81aeb