### PR TITLE
fix: price list overrides does not fire request

### DIFF
--- a/src/components/templates/price-overrides/index.tsx
+++ b/src/components/templates/price-overrides/index.tsx
@@ -1,6 +1,6 @@
 import { MoneyAmount, ProductVariant } from "@medusajs/medusa"
 import React from "react"
-import { Control, Controller, useForm } from "react-hook-form"
+import { Control, Controller, useForm, useWatch } from "react-hook-form"
 import Checkbox, { CheckboxProps } from "../../atoms/checkbox"
 import Button from "../../fundamentals/button"
 import Modal from "../../molecules/modal"
@@ -12,11 +12,16 @@ const MODES = {
   SELECTED_ONLY: "selected",
 }
 
+export type PriceOverridesFormValues = {
+  variants: string[]
+  prices: MoneyAmount[]
+}
+
 type PriceOverridesType = {
   onClose: () => void
   prices: MoneyAmount[]
   variants: ProductVariant[]
-  onSubmit: (data: any) => void
+  onSubmit: (values: PriceOverridesFormValues) => void
 }
 
 const PriceOverrides = ({
@@ -26,14 +31,41 @@ const PriceOverrides = ({
   onSubmit,
 }: PriceOverridesType) => {
   const [mode, setMode] = React.useState(MODES.SELECTED_ONLY)
-  const { handleSubmit, control } = useForm({
+  const { handleSubmit, control, reset } = useForm<PriceOverridesFormValues>({
     defaultValues: {
       variants: [],
       prices,
     },
   })
 
-  const onClick = handleSubmit(onSubmit)
+  const onClick = handleSubmit((values) => {
+    if (mode === MODES.APPLY_ALL) {
+      onSubmit({
+        ...values,
+        variants: variants.map((variant) => variant.id),
+      })
+    } else {
+      onSubmit({
+        ...values,
+        // remove null or undefined
+        variants: values.variants.filter(Boolean),
+      })
+    }
+  })
+
+  // set default variant
+  React.useEffect(() => {
+    const selectedVariantId = prices[0].variant_id
+    const selectedIndex = variants.findIndex(
+      (variant) => variant.id === selectedVariantId
+    )
+    const variantOptions = Array(variants.length).fill(null)
+    variantOptions[selectedIndex] = selectedVariantId
+    reset({
+      prices,
+      variants: variantOptions,
+    })
+  }, [variants, prices])
 
   return (
     <>
@@ -65,6 +97,7 @@ const PriceOverrides = ({
                   label={`${variant.title} (SKU: ${variant.sku})`}
                   id={variant.id}
                   index={idx}
+                  value={variant.id}
                 />
               </div>
             ))}
@@ -132,8 +165,14 @@ const ControlledCheckbox = ({
   name,
   id,
   index,
+  value,
   ...props
 }: ControlledCheckboxProps) => {
+  const variants = useWatch<string[]>({
+    control,
+    name,
+  })
+
   return (
     <Controller
       control={control}
@@ -144,19 +183,16 @@ const ControlledCheckbox = ({
             className="shrink-0 inter-small-regular"
             {...props}
             {...field}
-            checked={field.value.some((value) => value === id)}
+            checked={variants?.some((variant) => variant === value)}
             onChange={(e) => {
               // copy field value
-              const valueCopy = [...(field.value || [])]
+              const valueCopy = [...(variants || [])] as any[]
 
               // update checkbox value
               valueCopy[index] = e.target.checked ? id : null
 
-              // remove nulls from field value
-              const cleanedValue = valueCopy.filter(Boolean)
-
               // update field value
-              field.onChange(cleanedValue)
+              field.onChange(valueCopy)
             }}
           />
         )

--- a/src/components/templates/price-overrides/index.tsx
+++ b/src/components/templates/price-overrides/index.tsx
@@ -34,7 +34,7 @@ const PriceOverrides = ({
   const { handleSubmit, control, reset } = useForm<PriceOverridesFormValues>({
     defaultValues: {
       variants: [],
-      prices,
+      prices: prices,
     },
   })
 
@@ -115,6 +115,7 @@ const PriceOverrides = ({
                   return (
                     <PriceAmount
                       value={field.value}
+                      key={price.id}
                       onChange={(amount) => {
                         field.onChange({
                           ...field.value,

--- a/src/components/templates/price-overrides/price-amount.tsx
+++ b/src/components/templates/price-overrides/price-amount.tsx
@@ -9,6 +9,7 @@ import MedusaPriceInput from "../../organisms/medusa-price-input"
 const PriceAmount = ({ value, onChange }) => {
   const { state: showRegions, toggle } = useToggleState()
 
+  const currencyName = currencies[value.currency_code?.toUpperCase()]?.name
   return (
     <div className="flex flex-col gap-3 py-3 first:border-t border-grey-20 border-solid border-b last:border-b-0">
       <div className="flex items-center justify-between">
@@ -16,7 +17,7 @@ const PriceAmount = ({ value, onChange }) => {
           <div className="inter-base-semibold">
             <span className="mr-2 uppercase">{value.currency_code}</span>
             <span className="inter-base-regular text-grey-50 capitalize">
-              {value.currency?.name}
+              {currencyName}
             </span>
           </div>
           {value.region?.countries ? (

--- a/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
+++ b/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
@@ -37,9 +37,16 @@ const EditPricesOverridesModal = ({
           onSubmit={(values) => {
             const updatedPrices = mapToPriceList(values)
 
-            updatePriceList.mutate({
-              prices: updatedPrices,
-            })
+            updatePriceList.mutate(
+              {
+                prices: updatedPrices,
+              },
+              {
+                onSuccess: () => {
+                  close()
+                },
+              }
+            )
           }}
         />
       ),

--- a/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
+++ b/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
@@ -31,7 +31,7 @@ const EditPricesOverridesModal = ({
       onBack: () => context.pop(),
       view: (
         <PriceOverrides
-          prices={variant.prices}
+          prices={variant.prices.filter((pr) => pr.price_list_id)}
           variants={product.variants}
           onClose={close}
           onSubmit={(values) => {
@@ -43,6 +43,7 @@ const EditPricesOverridesModal = ({
               },
               {
                 onSuccess: () => {
+                  context.pop()
                   close()
                 },
               }

--- a/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
+++ b/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
@@ -1,4 +1,5 @@
 import { Product } from "@medusajs/medusa"
+import { useAdminUpdatePriceList } from "medusa-react"
 import * as React from "react"
 import Button from "../../../../../../components/fundamentals/button"
 import { CollapsibleTree } from "../../../../../../components/molecules/collapsible-tree"
@@ -8,6 +9,8 @@ import LayeredModal, {
 } from "../../../../../../components/molecules/modal/layered-modal"
 import PriceOverrides from "../../../../../../components/templates/price-overrides"
 import ProductVariantLeaf from "./product-variant-leaf"
+import { useParams } from "@reach/router"
+import { mapToPriceList } from "./mappers"
 
 type EditPricesOverridesModalProps = {
   product: Product
@@ -19,6 +22,8 @@ const EditPricesOverridesModal = ({
   product,
 }: EditPricesOverridesModalProps) => {
   const context = useLayeredModal()
+  const { id: priceListId } = useParams()
+  const updatePriceList = useAdminUpdatePriceList(priceListId)
 
   const getOnClick = (variant) => () =>
     context.push({
@@ -29,7 +34,13 @@ const EditPricesOverridesModal = ({
           prices={variant.prices}
           variants={product.variants}
           onClose={close}
-          onSubmit={console.log}
+          onSubmit={(values) => {
+            const updatedPrices = mapToPriceList(values)
+
+            updatePriceList.mutate({
+              prices: updatedPrices,
+            })
+          }}
         />
       ),
     })

--- a/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/mappers.tsx
+++ b/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/mappers.tsx
@@ -1,0 +1,17 @@
+import { AdminPostPriceListsPriceListPriceListReq } from "@medusajs/medusa"
+import { PriceOverridesFormValues } from "../../../../../../components/templates/price-overrides"
+import xorObjFields from "../../../../../../utils/xorObjFields"
+
+export const mapToPriceList = (values: PriceOverridesFormValues) => {
+  return values.prices
+    .map((price) => {
+      return values.variants.map((variant) => ({
+        variant_id: variant,
+        ...xorObjFields(price, "currency_code", "region_id"),
+        amount: price.amount,
+        min_quantity: price.min_quantity,
+        max_quantity: price.max_quantity,
+      }))
+    })
+    .flat(1) as AdminPostPriceListsPriceListPriceListReq["prices"]
+}

--- a/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/mappers.tsx
+++ b/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/mappers.tsx
@@ -6,6 +6,7 @@ export const mapToPriceList = (values: PriceOverridesFormValues) => {
   return values.prices
     .map((price) => {
       return values.variants.map((variant) => ({
+        id: price.id,
         variant_id: variant,
         ...xorObjFields(price, "currency_code", "region_id"),
         amount: price.amount,

--- a/src/utils/xorObjFields.ts
+++ b/src/utils/xorObjFields.ts
@@ -1,0 +1,4 @@
+const xorObjFields = (obj: Record<string, any>, keyA: string, keyB: string) =>
+  obj[keyA] ? { [keyA]: obj[keyA] } : { [keyB]: obj[keyB] }
+
+export default xorObjFields


### PR DESCRIPTION
### What 

- price list overrides modal did not fire a request when the "save and close" button is clicked

### How

- add mutation from `medusa-react`
- fixed behavior of checkboxes when selecting variants

