### PR TITLE
Fix: Unable to save subsequent products without refreshing the page

### DIFF
--- a/src/domain/products/new.tsx
+++ b/src/domain/products/new.tsx
@@ -84,10 +84,12 @@ const SaveNotification = ({ isLoading = false }) => {
 
   const onPublish = (values: FieldValues) => {
     onSubmit({ ...values, status: "published" })
+    resetForm()
   }
 
   const onSaveDraft = (values: FieldValues) => {
     onSubmit({ ...values, status: "draft" })
+    resetForm()
   }
 
   const isDirty = checkForDirtyState(


### PR DESCRIPTION
fix(products): addresses issue where subsequent products are unable to be created unless the window is refreshed due to form values not being updated

Bigger picture discussion around these forms might be warranted.
I feel like if the context was pulled up higher and used as the single source of truth, it would make working within these form pages easier. For example, the images are currently unable to be saved along with the form details in this form, so it would be nice to use the form context as the source of truth for those images.