### PR TITLE
Fix: Price list focus modal adjustments

### DIFF
--- a/src/domain/pricing/details/sections/header.tsx
+++ b/src/domain/pricing/details/sections/header.tsx
@@ -50,7 +50,11 @@ const Header = ({ priceList }) => {
       </div>
       {isOpen && (
         <Fade isVisible={isOpen} isFullScreen={true}>
-          <PriceListForm id={priceList.id} viewType={ViewType.EDIT_DETAILS} />
+          <PriceListForm
+            id={priceList.id}
+            onClose={() => setIsOpen(false)}
+            viewType={ViewType.EDIT_DETAILS}
+          />
         </Fade>
       )}
     </HeadingBodyCard>

--- a/src/domain/pricing/pricing-form/form-header/index.tsx
+++ b/src/domain/pricing/pricing-form/form-header/index.tsx
@@ -25,7 +25,11 @@ const FormHeader = (props: PriceListFormProps & { onClose?: () => void }) => {
   const notification = useNotification()
 
   const closeForm = () => {
-    navigate(-1)
+    if (props.viewType !== ViewType.CREATE && props.onClose) {
+      props.onClose()
+    } else {
+      navigate(-1)
+    }
   }
 
   const createPriceList = useAdminCreatePriceList()

--- a/src/domain/pricing/pricing-form/form/mappers.ts
+++ b/src/domain/pricing/pricing-form/form/mappers.ts
@@ -19,8 +19,8 @@ export const mapPriceListToFormValues = (
     description: priceList.description,
     type: priceList.type,
     name: priceList.name,
-    ends_at: priceList.ends_at,
-    starts_at: priceList.starts_at,
+    ends_at: priceList.ends_at ? new Date(priceList.ends_at) : null,
+    starts_at: priceList.starts_at ? new Date(priceList.starts_at) : null,
     prices: priceList.prices.map((p) => ({
       amount: p.amount,
       max_quantity: p.max_quantity,

--- a/src/domain/pricing/pricing-form/sections/configuration.tsx
+++ b/src/domain/pricing/pricing-form/sections/configuration.tsx
@@ -20,7 +20,7 @@ const checkForEnabledConfigs = (
 ): string[] => {
   const enabledConfigs: string[] = []
 
-  if (config.customer_groups) {
+  if (config.customer_groups?.length > 0) {
     enabledConfigs.push(ConfigurationField.CUSTOMER_GROUPS)
   }
   if (config.starts_at) {


### PR DESCRIPTION
**What**
- toggle "Customer groups" off as default when opening configurations
- ensure that cancel and close on focus modal in pricelist detail closes focus modal
- parse starts_at and ends_at as dates when converting to form values

**Why**
- customer groups was toggled on (because `[]` is truthy) 
- cancel and close navigated to list view from detail when closing modal 
- datepickers were broken when editing due to the form values being strings rather than dates 