### PR TITLE
fix(deps)/re-add @types/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/line-clamp": "^0.3.1",
     "@types/randomatic": "^3.1.3",
+    "@types/react": "16.14.26",
     "@types/react-datepicker": "^4.3.4",
     "@types/react-table": "^7.7.9",
     "@typescript-eslint/parser": "^5.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4803,6 +4803,15 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/react@16.14.26":
+  version "16.14.26"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.26.tgz#82540a240ba7207ebe87d9579051bc19c9ef7605"
+  integrity sha512-c/5CYyciOO4XdFcNhZW1O2woVx86k4T+DO2RorHZL7EhitkNQgSD/SgpdZJAUJa/qjVgOmTM44gHkAdZSXeQuQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"


### PR DESCRIPTION
**What**

#577 seems to have stripped the project from React types, resulting in many TS errors. This PR adds the version of `@types/react` that matches the version of React used, as closely as possible.