### PR TITLE
Fix: Allow null updates for starts_at ends_at and customer groups

### DIFF
--- a/src/domain/pricing/pricing-form/form-header/index.tsx
+++ b/src/domain/pricing/pricing-form/form-header/index.tsx
@@ -66,7 +66,7 @@ const FormHeader = (props: PriceListFormProps & { onClose?: () => void }) => {
   const onUpdateDetails = (values: PriceListFormValues) => {
     updatePriceList.mutate(mapFormValuesToUpdatePriceListDetails(values), {
       onSuccess: ({ price_list }) => {
-        navigate(`/a/pricing/${price_list.id}`)
+        closeForm()
       },
       onError: (error) => {
         notification("Error", getErrorMessage(error), "error")

--- a/src/domain/pricing/pricing-form/form/mappers.ts
+++ b/src/domain/pricing/pricing-form/form/mappers.ts
@@ -77,9 +77,9 @@ export const mapFormValuesToUpdatePriceListDetails = (
     description: values.description || undefined,
     customer_groups: values.customer_groups
       ? values.customer_groups.map((cg) => ({ id: cg.value }))
-      : undefined,
-    ends_at: values.ends_at || undefined,
-    starts_at: values.starts_at || undefined,
+      : [],
+    ends_at: values.ends_at,
+    starts_at: values.starts_at,
     type: values.type || undefined,
   }
 }


### PR DESCRIPTION
**What**
- use null updates if `starts_at` or `ends_at` are not configured. 
- use empty array updates if `customer_groups` are not defined

**Why**
- to allow removing configurations in price lists