### PR TITLE
fix: center spinner in selectable table

### DIFF
--- a/src/components/templates/selectable-table/index.tsx
+++ b/src/components/templates/selectable-table/index.tsx
@@ -121,6 +121,7 @@ export const SelectableTable = <
         {...options}
         {...table.getTableProps()}
         handleSearch={options.enableSearch ? debouncedSearch : undefined}
+        className="min-h-[350px] relative"
       >
         {renderHeaderGroup && (
           <Table.Head>
@@ -132,9 +133,11 @@ export const SelectableTable = <
 
         <Table.Body {...table.getTableBodyProps()}>
           {isLoading ? (
-            <Spinner size="large" />
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+              <Spinner size="large" variant="secondary" />
+            </div>
           ) : (
-            table.rows.map((row, i) => {
+            table.rows.map((row) => {
               table.prepareRow(row)
               return renderRow({ row })
             })


### PR DESCRIPTION
### What

- fixes the spinner's position in the `SelectableTable` component

### Why

- micro improvement to the UX/UI

### How

- gave the table a min-height, then wrapped the spinner inside a div and centered it

Closes #584 