### PR TITLE
fix: Link to Order from DraftOrder broken

### DIFF
--- a/src/domain/orders/draft-orders/details.tsx
+++ b/src/domain/orders/draft-orders/details.tsx
@@ -164,7 +164,7 @@ const DraftOrderDetails = ({ id }) => {
                     variant="secondary"
                     size="small"
                     onClick={() =>
-                      navigate(`/a/orders/${draft_order.order_id}}`)
+                      navigate(`/a/orders/${draft_order.order_id}`)
                     }
                   >
                     Go to Order


### PR DESCRIPTION
**What**

- fixed Link to Order from DraftOrder broken

**How**

- Removed the extra `}` in the end of the the link

Closes https://github.com/medusajs/admin/issues/564