### PR TITLE
include status in product query for table

### DIFF
--- a/src/components/templates/product-table/index.tsx
+++ b/src/components/templates/product-table/index.tsx
@@ -18,7 +18,7 @@ const DEFAULT_PAGE_SIZE_TILE_VIEW = 18
 type ProductTableProps = {}
 
 const defaultQueryProps = {
-  fields: "id,title,type,thumbnail",
+  fields: "id,title,type,thumbnail,status",
   expand: "variants,options,variants.prices,variants.options,collection,tags",
   is_giftcard: false,
 }


### PR DESCRIPTION
**What**
- include status in product table query

**Why**
- To allow switching between "publish" and "unpublish" in the actionables for a row
- To include a descriptive status dot in the status column

**Testing**
Before
![image](https://user-images.githubusercontent.com/88927411/174250347-a1c4d789-5f81-4c15-b85d-e6f913dd3d26.png)

After
![image](https://user-images.githubusercontent.com/88927411/174250790-06ff57aa-cc9b-431c-ad0b-789eb5445e77.png)