### PR TITLE
feat: add quick way to copy skus when creating swaps/claims

### DIFF
--- a/src/components/organisms/rma-select-product-table/index.tsx
+++ b/src/components/organisms/rma-select-product-table/index.tsx
@@ -11,6 +11,7 @@ import MinusIcon from "../../fundamentals/icons/minus-icon"
 import PlusIcon from "../../fundamentals/icons/plus-icon"
 import { LayeredModalContext } from "../../molecules/modal/layered-modal"
 import Table from "../../molecules/table"
+import CopyToClipboard from "../../atoms/copy-to-clipboard"
 
 type RMASelectProductTableProps = {
   order: Omit<Order, "beforeInsert">
@@ -163,7 +164,17 @@ const RMASelectProductTable: React.FC<RMASelectProductTableProps> = ({
                       <span>
                         <span className="text-grey-90">{item.title}</span>
                       </span>
-                      <span>{item?.variant?.title || ""}</span>
+                      <div className="flex gap-4">
+                        {item?.variant?.title && (
+                          <span>{item.variant.title}</span>
+                        )}
+                        {item?.variant?.sku && (
+                            <CopyToClipboard
+                              value={item.variant.sku}
+                              iconSize={14}
+                            />
+                        )}
+                      </div>
                     </div>
                   </div>
                 </Table.Cell>


### PR DESCRIPTION
**What**
Creates a simple way for store operators to copy SKUs when creating claims and exchanges.

<img width="727" alt="image" src="https://user-images.githubusercontent.com/7554214/176508820-924a69f3-d46f-4fc4-9681-264a2d284a2b.png">
