### PR TITLE
fix: remove thumbnail when removing all images

### DIFF
--- a/src/domain/gift-cards/manage/form/mappers.ts
+++ b/src/domain/gift-cards/manage/form/mappers.ts
@@ -1,9 +1,7 @@
 export const formValuesToUpdateGiftCardMapper = (values) => {
   const payload = {
     ...values,
-    thumbnail: values.images?.length
-      ? values.images[values.thumbnail]
-      : undefined,
+    thumbnail: values.images?.length ? values.images[values.thumbnail] : null,
   }
 
   if (values.images) {

--- a/src/domain/products/product-form/form/mappers.ts
+++ b/src/domain/products/product-form/form/mappers.ts
@@ -104,9 +104,7 @@ export const formValuesToUpdateProductMapper = (values) => {
     handle: values.handle,
     status: values.status,
     description: values.description,
-    thumbnail: values.images.length
-      ? values.images[values.thumbnail]
-      : undefined,
+    thumbnail: values.images.length ? values.images[values.thumbnail] : null,
     collection_id: values?.collection ? values.collection.value : null,
     type: values?.type
       ? { id: values.type.value, value: values.type.label }


### PR DESCRIPTION
What

When the last image is removed from a product or gift card, the thumbnail persists. This gives the illusion of the image not being properly deleted. To avoid confusion, this PR removes the thumbnail if all images are removed from a product or gift card.

Note

fixes #626 