### PR TITLE
fix: Use order currency code instead of region on order lines

### DIFF
--- a/src/domain/orders/details/index.tsx
+++ b/src/domain/orders/details/index.tsx
@@ -358,7 +358,11 @@ const OrderDetails = ({ id }) => {
             <BodyCard className={"w-full mb-4 min-h-0 h-auto"} title="Summary">
               <div className="mt-6">
                 {order?.items?.map((item, i) => (
-                  <OrderLine key={i} item={item} region={order?.region} />
+                  <OrderLine
+                    key={i}
+                    item={item}
+                    currencyCode={order?.currency_code}
+                  />
                 ))}
                 <DisplayTotal
                   currency={order?.currency_code}

--- a/src/domain/orders/details/order-line/index.tsx
+++ b/src/domain/orders/details/order-line/index.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { formatAmountWithSymbol } from "../../../../utils/prices"
 
-const OrderLine = ({ item, region }) => {
+const OrderLine = ({ item, currencyCode }) => {
   return (
     <div className="flex justify-between mb-1 h-[64px] py-2 mx-[-5px] px-[5px] hover:bg-grey-5 rounded-rounded">
       <div className="flex space-x-4 justify-center">
@@ -24,9 +24,9 @@ const OrderLine = ({ item, region }) => {
           <div className="inter-small-regular text-grey-50">
             {formatAmountWithSymbol({
               amount: item.unit_price,
-              currency: region?.currency_code,
+              currency: currencyCode,
               digits: 2,
-              tax: item.tax_lines
+              tax: item.tax_lines,
             })}
           </div>
           <div className="inter-small-regular text-grey-50">
@@ -35,15 +35,13 @@ const OrderLine = ({ item, region }) => {
           <div className="inter-small-regular text-grey-90">
             {formatAmountWithSymbol({
               amount: item.unit_price * item.quantity,
-              currency: region?.currency_code,
+              currency: currencyCode,
               digits: 2,
-              tax: item.tax_lines
+              tax: item.tax_lines,
             })}
           </div>
         </div>
-        <div className="inter-small-regular text-grey-50">
-          {region?.currency_code.toUpperCase()}
-        </div>
+        <div className="inter-small-regular text-grey-50">{currencyCode}</div>
       </div>
     </div>
   )


### PR DESCRIPTION
**What**
Admin throws when retrieving order with deleted region because it's trying to access currency code of null