### PR TITLE
Feat: Product detail sc info

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -224,7 +224,7 @@
 
 @layer components {
   .badge {
-    @apply w-min py-0.5 px-2 rounded inter-small-semibold;
+    @apply w-min py-0.5 px-2 rounded-rounded inter-small-semibold;
   }
 
   .badge-primary {
@@ -241,6 +241,10 @@
 
   .badge-warning {
     @apply bg-yellow-40 bg-opacity-20 text-yellow-60;
+  }
+
+  .badge-ghost {
+    @apply text-grey-90 border border-grey-20 whitespace-nowrap;
   }
 
   .badge-default {
@@ -272,7 +276,7 @@
   }
 
   .btn-danger {
-   @apply bg-grey-0 text-rose-50 border border-grey-20 hover:bg-grey-10 active:bg-grey-20 disabled:bg-grey-0 disabled:text-grey-30
+    @apply bg-grey-0 text-rose-50 border border-grey-20 hover:bg-grey-10 active:bg-grey-20 disabled:bg-grey-0 disabled:text-grey-30;
   }
 
   .btn-nuclear {
@@ -403,7 +407,7 @@
   }
 
   .accordion-margin-transition {
-    @apply transition-[margin] duration-300 ease-[cubic-bezier(0.87,0,0.13,1)]
+    @apply transition-[margin] duration-300 ease-[cubic-bezier(0.87,0,0.13,1)];
   }
 
   .col-tree:last-child .bottom-half-dash {

--- a/src/components/fundamentals/badge/index.tsx
+++ b/src/components/fundamentals/badge/index.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx"
 import React from "react"
 
 type BadgeProps = {
-  variant: "primary" | "danger" | "success" | "warning" | "default"
+  variant: "primary" | "danger" | "success" | "warning" | "ghost" | "default"
 } & React.HTMLAttributes<HTMLDivElement>
 
 const Badge: React.FC<BadgeProps> = ({
@@ -17,6 +17,7 @@ const Badge: React.FC<BadgeProps> = ({
     ["badge-danger"]: variant === "danger",
     ["badge-success"]: variant === "success",
     ["badge-warning"]: variant === "warning",
+    ["badge-ghost"]: variant === "ghost",
     ["badge-default"]: variant === "default",
   })
 

--- a/src/components/fundamentals/icons/channels-icon.tsx
+++ b/src/components/fundamentals/icons/channels-icon.tsx
@@ -54,9 +54,9 @@ const ChannelsIcon: React.FC<IconProps> = ({
       <path
         d="M15.6361 12H7.53613"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   )

--- a/src/components/fundamentals/icons/channels-icon.tsx
+++ b/src/components/fundamentals/icons/channels-icon.tsx
@@ -53,7 +53,7 @@ const ChannelsIcon: React.FC<IconProps> = ({
       />
       <path
         d="M15.6361 12H7.53613"
-        stroke="#111827"
+        stroke={color}
         stroke-width="1.5"
         stroke-linecap="round"
         stroke-linejoin="round"

--- a/src/components/fundamentals/icons/channels-icon.tsx
+++ b/src/components/fundamentals/icons/channels-icon.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+
+import IconProps from "./types/icon-type"
+
+const ChannelsIcon: React.FC<IconProps> = ({
+  size = "24px",
+  color = "currentColor",
+  ...attributes
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...attributes}
+    >
+      <path
+        d="M17.6627 7.05C18.7811 7.05 19.6877 6.14338 19.6877 5.025C19.6877 3.90662 18.7811 3 17.6627 3C16.5443 3 15.6377 3.90662 15.6377 5.025C15.6377 6.14338 16.5443 7.05 17.6627 7.05Z"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.6627 14.025C18.7811 14.025 19.6877 13.1184 19.6877 12C19.6877 10.8816 18.7811 9.97498 17.6627 9.97498C16.5443 9.97498 15.6377 10.8816 15.6377 12C15.6377 13.1184 16.5443 14.025 17.6627 14.025Z"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5.5123 14.025C6.63068 14.025 7.5373 13.1184 7.5373 12C7.5373 10.8816 6.63068 9.97498 5.5123 9.97498C4.39393 9.97498 3.4873 10.8816 3.4873 12C3.4873 13.1184 4.39393 14.025 5.5123 14.025Z"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.6627 21C18.7811 21 19.6877 20.0933 19.6877 18.975C19.6877 17.8566 18.7811 16.95 17.6627 16.95C16.5443 16.95 15.6377 17.8566 15.6377 18.975C15.6377 20.0933 16.5443 21 17.6627 21Z"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M15.6369 5.02502H13.3869C12.3924 5.02502 11.5869 5.83052 11.5869 6.82502V17.175C11.5869 18.1695 12.3924 18.975 13.3869 18.975H15.6369"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M15.6361 12H7.53613"
+        stroke="#111827"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default ChannelsIcon

--- a/src/domain/products/product-form/index.tsx
+++ b/src/domain/products/product-form/index.tsx
@@ -1,5 +1,6 @@
 import { useAdminStore } from "medusa-react"
 import * as React from "react"
+import FeatureToggle from "../../../components/fundamentals/feature-toggle"
 import Breadcrumb from "../../../components/molecules/breadcrumb"
 import RawJSON from "../../../components/organisms/raw-json"
 import { useProductForm } from "./form/product-form-context"
@@ -30,7 +31,9 @@ const ProductForm = ({ product, isEdit = false }: ProductFormProps) => {
       <div className="flex flex-col space-y-base pb-2xlarge">
         <General isEdit={isEdit} product={product} showViewOptions={!isEdit} />
 
-        <SalesChannels isEdit={isEdit} product={product} />
+        <FeatureToggle featureFlag="sales_channels">
+          <SalesChannels isEdit={isEdit} product={product} />
+        </FeatureToggle>
 
         {(isVariantsView || isEdit) && (
           <Variants isEdit={isEdit} product={product} />

--- a/src/domain/products/product-form/index.tsx
+++ b/src/domain/products/product-form/index.tsx
@@ -1,10 +1,12 @@
 import { useAdminStore } from "medusa-react"
 import * as React from "react"
+import Breadcrumb from "../../../components/molecules/breadcrumb"
 import RawJSON from "../../../components/organisms/raw-json"
 import { useProductForm } from "./form/product-form-context"
 import General from "./sections/general"
 import Images from "./sections/images"
 import Prices from "./sections/prices"
+import SalesChannels from "./sections/sales-channels"
 import StockAndInventory from "./sections/stock-inventory"
 import Variants from "./sections/variants"
 
@@ -19,34 +21,36 @@ const ProductForm = ({ product, isEdit = false }: ProductFormProps) => {
   const currencyCodes = store?.currencies.map((currency) => currency.code)
 
   return (
-    <>
-      <div>
+    <div>
+      <Breadcrumb
+        currentPage={"Product Details"}
+        previousBreadcrumb={"Products"}
+        previousRoute="/a/products"
+      />
+      <div className="flex flex-col space-y-base pb-2xlarge">
         <General isEdit={isEdit} product={product} showViewOptions={!isEdit} />
-      </div>
-      {(isVariantsView || isEdit) && (
-        <div className="mt-large">
+
+        <SalesChannels isEdit={isEdit} product={product} />
+
+        {(isVariantsView || isEdit) && (
           <Variants isEdit={isEdit} product={product} />
-        </div>
-      )}
-      {!isVariantsView && !isEdit && (
-        <div className="mt-large">
+        )}
+
+        {!isVariantsView && !isEdit && (
           <Prices
             currencyCodes={currencyCodes}
             defaultCurrencyCode={store?.default_currency_code}
             defaultAmount={1000}
           />
-        </div>
-      )}
-      <div className="mt-large">
+        )}
+
         <Images />
-      </div>
-      <div className="mt-large">
+
         <StockAndInventory />
-      </div>
-      <div className="mt-large">
+
         <RawJSON data={product} title="Raw product" />
       </div>
-    </>
+    </div>
   )
 }
 

--- a/src/domain/products/product-form/sections/sales-channels.tsx
+++ b/src/domain/products/product-form/sections/sales-channels.tsx
@@ -43,10 +43,7 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
             product.sales_channels
               .slice(0, 3)
               .map((sc) => (
-                <SalesChannelBadge
-                  channel={sc}
-                  onClick={() => console.log("testing")}
-                />
+                <SalesChannelBadge channel={sc} onClick={() => {}} />
               ))}
         </div>
         {remainder > 0 && (
@@ -81,7 +78,7 @@ const SalesChannelBadge: React.FC<SalesChannelBadgeProps> = ({
   onClick,
 }) => {
   return (
-    <Badge variant="ghost">
+    <Badge variant="ghost" className="pl-4 pr-3">
       <div className="flex py-1.5 items-center">
         <span className="inter-base-regular text-grey-90">{channel.name}</span>
         <button onClick={onClick} className="text-grey-40 ml-2">

--- a/src/domain/products/product-form/sections/sales-channels.tsx
+++ b/src/domain/products/product-form/sections/sales-channels.tsx
@@ -32,9 +32,12 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
     >
       <div className="flex space-x-2">
         <div className="flex space-x-2 max-w-[600px] overflow-clip">
-          {product?.sales_channels?.slice(0, 3).map((sc) => (
-            <SalesChannelBadge channel={sc} onClick={() => {}} />
-          ))}
+          {isEdit &&
+            product.sales_channels
+              ?.slice(0, 3)
+              .map((sc) => (
+                <SalesChannelBadge channel={sc} onClick={() => {}} />
+              ))}
         </div>
         {remainder > 0 && (
           <Badge variant="ghost">
@@ -47,7 +50,7 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
       <span className="inter-base-regular text-grey-50 mb-large mt-base">
         Available in{" "}
         <span className="inter-base-semibold text-grey-90">
-          {product?.sales_channels?.length || 0}
+          {isEdit ? product.sales_channels?.length : 0}
         </span>{" "}
         out of <span className="inter-base-semibold text-grey-90">{count}</span>{" "}
         Sales Channels

--- a/src/domain/products/product-form/sections/sales-channels.tsx
+++ b/src/domain/products/product-form/sections/sales-channels.tsx
@@ -21,15 +21,8 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
   isEdit = false,
   product,
 }) => {
-  const { count, isLoading } = useAdminSalesChannels()
-
-  const [remainder, setRemainder] = React.useState(0)
-
-  useEffect(() => {
-    if (product.sales_channels) {
-      setRemainder(Math.max(product.sales_channels.length - 3, 0))
-    }
-  }, [isLoading])
+  const { count } = useAdminSalesChannels()
+  const remainder = Math.max(product.sales_channels.length - 3, 0)
 
   return (
     <BodyCard
@@ -39,12 +32,9 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
     >
       <div className="flex space-x-2">
         <div className="flex space-x-2 max-w-[600px] overflow-clip">
-          {product.sales_channels &&
-            product.sales_channels
-              .slice(0, 3)
-              .map((sc) => (
-                <SalesChannelBadge channel={sc} onClick={() => {}} />
-              ))}
+          {product.sales_channels?.slice(0, 3).map((sc) => (
+            <SalesChannelBadge channel={sc} onClick={() => {}} />
+          ))}
         </div>
         {remainder > 0 && (
           <Badge variant="ghost">

--- a/src/domain/products/product-form/sections/sales-channels.tsx
+++ b/src/domain/products/product-form/sections/sales-channels.tsx
@@ -22,7 +22,7 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
   product,
 }) => {
   const { count } = useAdminSalesChannels()
-  const remainder = Math.max(product.sales_channels.length - 3, 0)
+  const remainder = Math.max(product?.sales_channels?.length - 3, 0)
 
   return (
     <BodyCard
@@ -32,7 +32,7 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
     >
       <div className="flex space-x-2">
         <div className="flex space-x-2 max-w-[600px] overflow-clip">
-          {product.sales_channels?.slice(0, 3).map((sc) => (
+          {product?.sales_channels?.slice(0, 3).map((sc) => (
             <SalesChannelBadge channel={sc} onClick={() => {}} />
           ))}
         </div>
@@ -47,7 +47,7 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
       <span className="inter-base-regular text-grey-50 mb-large mt-base">
         Available in{" "}
         <span className="inter-base-semibold text-grey-90">
-          {product.sales_channels.length}
+          {product?.sales_channels?.length || 0}
         </span>{" "}
         out of <span className="inter-base-semibold text-grey-90">{count}</span>{" "}
         Sales Channels

--- a/src/domain/products/product-form/sections/sales-channels.tsx
+++ b/src/domain/products/product-form/sections/sales-channels.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect } from "react"
+import { Product, SalesChannel } from "@medusajs/medusa"
+import { useAdminSalesChannels } from "medusa-react"
+import Badge from "../../../../components/fundamentals/badge"
+import Button from "../../../../components/fundamentals/button"
+import ChannelsIcon from "../../../../components/fundamentals/icons/channels-icon"
+import CrossIcon from "../../../../components/fundamentals/icons/cross-icon"
+import BodyCard from "../../../../components/organisms/body-card"
+
+type SalesChannelsProps = {
+  isEdit?: boolean
+  product: Product
+}
+
+type SalesChannelBadgeProps = {
+  channel: SalesChannel
+  onClick: () => void
+}
+
+const SalesChannels: React.FC<SalesChannelsProps> = ({
+  isEdit = false,
+  product,
+}) => {
+  const { count, isLoading } = useAdminSalesChannels()
+
+  const [remainder, setRemainder] = React.useState(0)
+
+  useEffect(() => {
+    if (product.sales_channels) {
+      setRemainder(Math.max(product.sales_channels.length - 3, 0))
+    }
+  }, [isLoading])
+
+  return (
+    <BodyCard
+      title="Sales Channels"
+      subtitle="This product will only be available in the default sales channel if left untouched."
+      className="min-h-[200px]"
+    >
+      <div className="flex space-x-2">
+        <div className="flex space-x-2 max-w-[600px] overflow-clip">
+          {product.sales_channels &&
+            product.sales_channels
+              .slice(0, 3)
+              .map((sc) => (
+                <SalesChannelBadge
+                  channel={sc}
+                  onClick={() => console.log("testing")}
+                />
+              ))}
+        </div>
+        {remainder > 0 && (
+          <Badge variant="ghost">
+            <div className="flex items-center h-full inter-base-regular text-grey-50">
+              + {remainder} more
+            </div>
+          </Badge>
+        )}
+      </div>
+      <span className="inter-base-regular text-grey-50 mb-large mt-base">
+        Available in{" "}
+        <span className="inter-base-semibold text-grey-90">
+          {product.sales_channels.length}
+        </span>{" "}
+        out of <span className="inter-base-semibold text-grey-90">{count}</span>{" "}
+        Sales Channels
+      </span>
+
+      <div>
+        <Button variant="ghost" size="small" className="border border-grey-20">
+          <ChannelsIcon size={20} />
+          Change availability
+        </Button>
+      </div>
+    </BodyCard>
+  )
+}
+
+const SalesChannelBadge: React.FC<SalesChannelBadgeProps> = ({
+  channel,
+  onClick,
+}) => {
+  return (
+    <Badge variant="ghost">
+      <div className="flex py-1.5 items-center">
+        <span className="inter-base-regular text-grey-90">{channel.name}</span>
+        <button onClick={onClick} className="text-grey-40 ml-2">
+          <CrossIcon size={16} />
+        </button>
+      </div>
+    </Badge>
+  )
+}
+
+export default SalesChannels

--- a/src/domain/products/product-form/sections/sales-channels.tsx
+++ b/src/domain/products/product-form/sections/sales-channels.tsx
@@ -64,7 +64,7 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
 
 const SalesChannelBadge: React.FC<SalesChannelBadgeProps> = ({ channel }) => {
   return (
-    <Badge variant="ghost" className="pl-4 pr-3">
+    <Badge variant="ghost" className="px-4">
       <div className="flex py-1.5 items-center">
         <span className="inter-base-regular text-grey-90">{channel.name}</span>
       </div>

--- a/src/domain/products/product-form/sections/sales-channels.tsx
+++ b/src/domain/products/product-form/sections/sales-channels.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect } from "react"
+import React from "react"
 import { Product, SalesChannel } from "@medusajs/medusa"
 import { useAdminSalesChannels } from "medusa-react"
 import Badge from "../../../../components/fundamentals/badge"
 import Button from "../../../../components/fundamentals/button"
 import ChannelsIcon from "../../../../components/fundamentals/icons/channels-icon"
-import CrossIcon from "../../../../components/fundamentals/icons/cross-icon"
 import BodyCard from "../../../../components/organisms/body-card"
 
 type SalesChannelsProps = {
@@ -14,7 +13,6 @@ type SalesChannelsProps = {
 
 type SalesChannelBadgeProps = {
   channel: SalesChannel
-  onClick: () => void
 }
 
 const SalesChannels: React.FC<SalesChannelsProps> = ({
@@ -35,9 +33,7 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
           {isEdit &&
             product.sales_channels
               ?.slice(0, 3)
-              .map((sc) => (
-                <SalesChannelBadge channel={sc} onClick={() => {}} />
-              ))}
+              .map((sc) => <SalesChannelBadge channel={sc} />)}
         </div>
         {remainder > 0 && (
           <Badge variant="ghost">
@@ -66,17 +62,11 @@ const SalesChannels: React.FC<SalesChannelsProps> = ({
   )
 }
 
-const SalesChannelBadge: React.FC<SalesChannelBadgeProps> = ({
-  channel,
-  onClick,
-}) => {
+const SalesChannelBadge: React.FC<SalesChannelBadgeProps> = ({ channel }) => {
   return (
     <Badge variant="ghost" className="pl-4 pr-3">
       <div className="flex py-1.5 items-center">
         <span className="inter-base-regular text-grey-90">{channel.name}</span>
-        <button onClick={onClick} className="text-grey-40 ml-2">
-          <CrossIcon size={16} />
-        </button>
       </div>
     </Badge>
   )


### PR DESCRIPTION
**What**
- Add sales channels element to product form guarded by a featureflag

**How**
- Add an additional badge variant
- Limit to show 3 (+ N more) sales channels

![image](https://user-images.githubusercontent.com/88927411/179688978-13b4e83a-4d06-4372-bc9e-8123706210fe.png)

Fixes CORE-269