### PR TITLE
feat: Show Toaster when editing Product in PriceList

### DIFF
--- a/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
+++ b/src/domain/pricing/details/sections/prices-details/edit-prices-overrides/index.tsx
@@ -12,6 +12,7 @@ import ProductVariantLeaf from "./product-variant-leaf"
 import { useParams } from "@reach/router"
 import { mapToPriceList } from "./mappers"
 import { mergeExistingWithDefault } from "../../../utils"
+import useNotification from "../../../../../../hooks/use-notification"
 
 type EditPricesOverridesModalProps = {
   product: Product
@@ -31,6 +32,8 @@ const EditPricesOverridesModal = ({
     currency_code: curr.code,
     amount: 0,
   })) as MoneyAmount[]
+
+  const notification = useNotification()
 
   const getOnClick = (variant) => () =>
     context.push({
@@ -57,6 +60,11 @@ const EditPricesOverridesModal = ({
                 onSuccess: () => {
                   context.pop()
                   close()
+                  notification(
+                    "Success",
+                    "Price overrides updated",
+                    "success"
+                  )
                 },
               }
             )


### PR DESCRIPTION
**What**
We want to display a Toaster when editing prices for a Product in a PriceList

Steps to reproduce:
1. Create PriceList
2. Edit Prices on a single product
3. Save and submit

**How**
Used `useNotification` hook when a mutation is successful. The resulting function from the `useNotification` hooks is invoked as such: `notification("Success", "Price overrides updated", "success").`

Closes #586 