### PR TITLE
feat: revamp input fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/react": "^16.14.26"
   },
   "dependencies": {
+    "@hookform/error-message": "^2.0.0",
     "@medusajs/medusa": "^1.3.4",
     "@radix-ui/react-accordion": "^0.1.6",
     "@radix-ui/react-avatar": "^0.1.3",

--- a/src/assets/styles/emoji-picker.css
+++ b/src/assets/styles/emoji-picker.css
@@ -94,3 +94,14 @@
 .emoji-picker-react .active-category-indicator-wrapper .active-category-indicator {
     display: none !important;
 }
+
+.emoji-scroll-wrapper {
+    overflow-x: hidden !important;
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+}
+
+.emoji-scroll-wrapper::-webkit-scrollbar {
+    /* chrome */
+    display: none;
+}

--- a/src/components/atoms/input-error/index.tsx
+++ b/src/components/atoms/input-error/index.tsx
@@ -1,0 +1,33 @@
+import { ErrorMessage } from "@hookform/error-message"
+import clsx from "clsx"
+import React from "react"
+
+type InputErrorProps = {
+  errors?: { [x: string]: unknown }
+  name?: string
+  className?: string
+}
+
+const InputError = ({ errors, name, className }: InputErrorProps) => {
+  if (!errors || !name) {
+    return null
+  }
+
+  return (
+    <ErrorMessage
+      name={name}
+      errors={errors}
+      render={({ messages }) =>
+        messages && (
+          <div className={clsx(className)}>
+            {Object.entries(messages).map(([type, message]) => (
+              <p key={type}>{message}</p>
+            ))}
+          </div>
+        )
+      }
+    />
+  )
+}
+
+export default InputError

--- a/src/components/atoms/input-error/index.tsx
+++ b/src/components/atoms/input-error/index.tsx
@@ -67,23 +67,4 @@ const MultipleMessages = ({ messages }: { messages: MultipleFieldErrors }) => {
   )
 }
 
-const getErrorMessage = (type: string, message?: string) => {
-  if (message) {
-    return message
-  }
-
-  switch (type) {
-    case "required":
-      return "This field is required"
-    case "minLength":
-      return "Input is too short"
-    case "maxLength":
-      return "Input is too long"
-    case "pattern":
-      return "Input is invalid"
-    default:
-      return "Input is invalid"
-  }
-}
-
 export default InputError

--- a/src/components/atoms/input-error/index.tsx
+++ b/src/components/atoms/input-error/index.tsx
@@ -1,6 +1,7 @@
 import { ErrorMessage } from "@hookform/error-message"
-import clsx from "clsx"
 import React from "react"
+import { MultipleFieldErrors } from "react-hook-form"
+import Tooltip from "../tooltip"
 
 type InputErrorProps = {
   errors?: { [x: string]: unknown }
@@ -18,17 +19,10 @@ const InputError = ({ errors, name, className }: InputErrorProps) => {
       name={name}
       errors={errors}
       render={({ message, messages }) => {
-        console.log(message, messages, errors)
         return (
           <div className="text-rose-50 inter-small-regular mt-2">
             {messages ? (
-              <ul className={clsx(className)}>
-                {Object.entries(messages).map(([type, message]) => (
-                  <li key={type}>
-                    <p>– {message}</p>
-                  </li>
-                ))}
-              </ul>
+              <MultipleMessages messages={messages} />
             ) : (
               <p>{message}</p>
             )}
@@ -37,6 +31,59 @@ const InputError = ({ errors, name, className }: InputErrorProps) => {
       }}
     />
   )
+}
+
+const MultipleMessages = ({ messages }: { messages: MultipleFieldErrors }) => {
+  const errors = Object.entries(messages).map(([_, message]) => message)
+
+  const displayedError = errors[0]
+  const remainderErrors = errors.slice(1)
+
+  return (
+    <div className="flex items-center gap-x-1 cursor-default">
+      <p>{displayedError}</p>
+      {remainderErrors?.length > 0 && (
+        <Tooltip
+          content={
+            <div className="text-rose-50 inter-small-regular">
+              {remainderErrors.map((e, i) => {
+                return (
+                  <p key={i}>
+                    {Array.from(Array(i + 1)).map((_) => "*")}
+                    {e}
+                  </p>
+                )
+              })}
+            </div>
+          }
+        >
+          <p>
+            +{remainderErrors.length}{" "}
+            {remainderErrors.length > 1 ? "errors" : "error"}
+          </p>
+        </Tooltip>
+      )}
+    </div>
+  )
+}
+
+const getErrorMessage = (type: string, message?: string) => {
+  if (message) {
+    return message
+  }
+
+  switch (type) {
+    case "required":
+      return "This field is required"
+    case "minLength":
+      return "Input is too short"
+    case "maxLength":
+      return "Input is too long"
+    case "pattern":
+      return "Input is invalid"
+    default:
+      return "Input is invalid"
+  }
 }
 
 export default InputError

--- a/src/components/atoms/input-error/index.tsx
+++ b/src/components/atoms/input-error/index.tsx
@@ -17,15 +17,24 @@ const InputError = ({ errors, name, className }: InputErrorProps) => {
     <ErrorMessage
       name={name}
       errors={errors}
-      render={({ messages }) =>
-        messages && (
-          <div className={clsx(className)}>
-            {Object.entries(messages).map(([type, message]) => (
-              <p key={type}>{message}</p>
-            ))}
+      render={({ message, messages }) => {
+        console.log(message, messages, errors)
+        return (
+          <div className="text-rose-50 inter-small-regular mt-2">
+            {messages ? (
+              <ul className={clsx(className)}>
+                {Object.entries(messages).map(([type, message]) => (
+                  <li key={type}>
+                    <p>– {message}</p>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>{message}</p>
+            )}
           </div>
         )
-      }
+      }}
     />
   )
 }

--- a/src/components/atoms/tooltip/index.tsx
+++ b/src/components/atoms/tooltip/index.tsx
@@ -41,7 +41,7 @@ const Tooltip = ({
           align="center"
           className={clsx(
             "inter-small-semibold text-grey-50",
-            "bg-grey-5 py-[6px] px-[12px] shadow-dropdown rounded",
+            "bg-grey-0 py-2 px-3 shadow-dropdown rounded-rounded",
             "border border-solid border-grey-20",
             "max-w-[220px]",
             className

--- a/src/components/fundamentals/icons/icons-overview.stories.tsx
+++ b/src/components/fundamentals/icons/icons-overview.stories.tsx
@@ -20,11 +20,12 @@ import PercentIcon from "./percent-icon"
 import PlusIcon from "./plus-icon"
 import PublishIcon from "./publish-icon"
 import SearchIcon from "./search-icon"
+import SidedMouthFaceIcon from "./sided-mouth-face"
 import TagIcon from "./tag-icon"
 import TruckIcon from "./truck-icon"
+import IconProps from "./types/icon-type"
 import UnpublishIcon from "./unpublish-icon"
 import UsersIcon from "./users-icon"
-import SidedMouthFaceIcon from "./sided-mouth-face"
 
 export default {
   title: "Fundamentals/Icons/Overview",
@@ -64,10 +65,10 @@ const icons = [
   <EditIcon />,
   <UnpublishIcon />,
   <PublishIcon />,
-  <SidedMouthFaceIcon />
+  <SidedMouthFaceIcon />,
 ]
 
-const Template = args => (
+const Template = (args: IconProps) => (
   <div className="grid grid-cols-6 gap-base">
     {icons.map((icon, key) => {
       return (
@@ -83,6 +84,7 @@ const Template = args => (
 )
 
 export const Overview = Template.bind({})
+// @ts-ignore
 Overview.args = {
   size: "24",
   color: "currentColor",

--- a/src/components/fundamentals/input-header.tsx
+++ b/src/components/fundamentals/input-header.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx"
 import React from "react"
 import IconTooltip from "../molecules/icon-tooltip"
 
@@ -6,6 +7,7 @@ export type InputHeaderProps = {
   required?: boolean
   tooltipContent?: string
   tooltip?: React.ReactNode
+  className?: string
 }
 
 const InputHeader: React.FC<InputHeaderProps> = ({
@@ -13,9 +15,15 @@ const InputHeader: React.FC<InputHeaderProps> = ({
   required = false,
   tooltipContent,
   tooltip,
+  className,
 }) => {
   return (
-    <div className="w-full flex inter-small-semibold text-grey-50 items-center">
+    <div
+      className={clsx(
+        "w-full flex inter-small-semibold text-grey-50 items-center",
+        className
+      )}
+    >
       <label>{label}</label>
       {required && <div className="text-rose-50 "> *</div>}
       {tooltip || tooltipContent ? (

--- a/src/components/molecules/emoji-picker/index.tsx
+++ b/src/components/molecules/emoji-picker/index.tsx
@@ -27,6 +27,7 @@ const EmojiPicker: React.FC<indexProps> = ({ onEmojiClick }) => {
         <Button
           variant="ghost"
           size="small"
+          type="button"
           className="focus:border-none focus:shadow-none text-grey-40 hover:text-violet-60 p-0 h-5 w-5"
         >
           <HappyIcon size={20} />
@@ -38,13 +39,15 @@ const EmojiPicker: React.FC<indexProps> = ({ onEmojiClick }) => {
         className="border bg-grey-0 border-grey-20 rounded-rounded shadow-dropdown overflow-hidden min-w-[200px] z-30"
       >
         <Picker
-          onEmojiClick={(e, data) => onEmojiClick(data.emoji)}
+          onEmojiClick={(_e, data) => onEmojiClick(data.emoji)}
           disableAutoFocus={true}
           skinTone={SKIN_TONE_NEUTRAL}
           groupNames={{ smileys_people: "PEOPLE" }}
           native
           disableSkinTonePicker={true}
+          // @ts-ignore
           searchPlaceholder={"Search Emoji..."}
+          // @ts-ignore
           groupNames={groupNames}
         />
       </DropdownMenu.Content>

--- a/src/components/molecules/input/index.tsx
+++ b/src/components/molecules/input/index.tsx
@@ -6,17 +6,19 @@ import React, {
   useImperativeHandle,
   useRef,
 } from "react"
+import InputError from "../../atoms/input-error"
 import MinusIcon from "../../fundamentals/icons/minus-icon"
 import PlusIcon from "../../fundamentals/icons/plus-icon"
 import InputHeader, { InputHeaderProps } from "../../fundamentals/input-header"
 
-export type InputProps = Omit<React.ComponentProps<"input">, "prefix"> &
+export type InputProps = Omit<React.ComponentPropsWithRef<"input">, "prefix"> &
   InputHeaderProps & {
     label?: string
     deletable?: boolean
     onDelete?: MouseEventHandler<HTMLSpanElement>
     onChange?: ChangeEventHandler<HTMLInputElement>
     onFocus?: FocusEventHandler<HTMLInputElement>
+    errors?: { [x: string]: unknown }
     prefix?: React.ReactNode
     props?: React.HTMLAttributes<HTMLDivElement>
   }
@@ -35,6 +37,7 @@ const InputField = React.forwardRef<HTMLInputElement, InputProps>(
       tooltipContent,
       tooltip,
       prefix,
+      errors,
       props,
       className,
       ...fieldProps
@@ -128,6 +131,7 @@ const InputField = React.forwardRef<HTMLInputElement, InputProps>(
               </button>
             </div>
           )}
+          <InputError name={name} errors={errors} />
         </div>
       </div>
     )

--- a/src/components/molecules/input/index.tsx
+++ b/src/components/molecules/input/index.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx"
 import React, {
   ChangeEventHandler,
   FocusEventHandler,
@@ -7,29 +8,25 @@ import React, {
 } from "react"
 import MinusIcon from "../../fundamentals/icons/minus-icon"
 import PlusIcon from "../../fundamentals/icons/plus-icon"
-import InputContainer from "../../fundamentals/input-container"
 import InputHeader, { InputHeaderProps } from "../../fundamentals/input-header"
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
+export type InputProps = Omit<React.ComponentProps<"input">, "prefix"> &
   InputHeaderProps & {
     label?: string
     deletable?: boolean
-    key?: string
     onDelete?: MouseEventHandler<HTMLSpanElement>
     onChange?: ChangeEventHandler<HTMLInputElement>
     onFocus?: FocusEventHandler<HTMLInputElement>
-    prefix?: string | React.ReactNode
-    startAdornment?: React.ReactNode
+    prefix?: React.ReactNode
     props?: React.HTMLAttributes<HTMLDivElement>
   }
 
-const InputField = React.forwardRef(
+const InputField = React.forwardRef<HTMLInputElement, InputProps>(
   (
     {
       placeholder,
       label,
       name,
-      key,
       required,
       deletable,
       onDelete,
@@ -40,16 +37,18 @@ const InputField = React.forwardRef(
       prefix,
       props,
       className,
-      startAdornment,
       ...fieldProps
     }: InputProps,
     ref
   ) => {
-    const inputRef = useRef(null)
+    const inputRef = useRef<HTMLInputElement | null>(null)
 
-    useImperativeHandle(ref, () => inputRef.current)
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => inputRef.current
+    )
 
-    const onClickChevronUp = () => {
+    const onNumberIncrement = () => {
       inputRef.current?.stepUp()
       if (onChange) {
         inputRef.current?.dispatchEvent(
@@ -62,7 +61,7 @@ const InputField = React.forwardRef(
       }
     }
 
-    const onClickChevronDown = () => {
+    const onNumberDecrement = () => {
       inputRef.current?.stepDown()
       if (onChange) {
         inputRef.current?.dispatchEvent(
@@ -76,28 +75,27 @@ const InputField = React.forwardRef(
     }
 
     return (
-      <InputContainer
-        className={className}
-        key={name}
+      <div
+        className={clsx("w-full", className)}
         onClick={() => !fieldProps.disabled && inputRef?.current?.focus()}
         {...props}
       >
         {label && (
-          <InputHeader {...{ label, required, tooltipContent, tooltip }} />
+          <InputHeader
+            {...{ label, required, tooltipContent, tooltip }}
+            className="mb-xsmall"
+          />
         )}
-        <div className="w-full flex items-center mt-1">
-          {startAdornment ? (
-            <div className="text-grey-40 mr-1.5">{startAdornment}</div>
-          ) : prefix ? (
+        <div className="w-full flex items-center bg-grey-5 border border-gray-20 px-small py-xsmall rounded-rounded h-10 focus-within:shadow-input focus-within:border-violet-60">
+          {prefix ? (
             <span className="text-grey-40 mr-2xsmall">{prefix}</span>
           ) : null}
           <input
-            className="bg-inherit outline-none outline-0 w-full remove-number-spinner leading-base text-grey-90 font-normal caret-violet-60 placeholder-grey-40"
+            className="bg-transparent outline-none outline-0 w-full remove-number-spinner leading-base text-grey-90 font-normal caret-violet-60 placeholder-grey-40"
             ref={inputRef}
             autoComplete="off"
             name={name}
-            key={key || name}
-            placeholder={placeholder || "Placeholder"}
+            placeholder={placeholder || label || "Placeholder"}
             onChange={onChange}
             onFocus={onFocus}
             required={required}
@@ -105,31 +103,37 @@ const InputField = React.forwardRef(
           />
 
           {deletable && (
-            <span onClick={onDelete} className="cursor-pointer ml-2">
+            <button
+              onClick={onDelete}
+              className="text-grey-50 w-4 h-4 hover:bg-grey-10 focus:bg-grey-20 rounded-soft cursor-pointer outline-none ml-2 flex items-center justify-center pb-px"
+              type="button"
+            >
               &times;
-            </span>
+            </button>
           )}
 
           {fieldProps.type === "number" && (
-            <div className="flex self-end">
-              <span
-                onClick={onClickChevronDown}
+            <div className="flex h-full items-center self-end">
+              <button
+                onClick={onNumberDecrement}
                 onMouseDown={(e) => e.preventDefault()}
-                className="mr-2 text-grey-50 w-4 h-4 hover:bg-grey-10 rounded-soft cursor-pointer"
+                className="mr-2 text-grey-50 w-4 h-4 hover:bg-grey-10 focus:bg-grey-20 rounded-soft cursor-pointer outline-none"
+                type="button"
               >
                 <MinusIcon size={16} />
-              </span>
-              <span
+              </button>
+              <button
                 onMouseDown={(e) => e.preventDefault()}
-                onClick={onClickChevronUp}
-                className="text-grey-50 w-4 h-4 hover:bg-grey-10 rounded-soft cursor-pointer"
+                onClick={onNumberIncrement}
+                className="text-grey-50 w-4 h-4 hover:bg-grey-10 focus:bg-grey-20 rounded-soft cursor-pointer outline-none"
+                type="button"
               >
                 <PlusIcon size={16} />
-              </span>
+              </button>
             </div>
           )}
         </div>
-      </InputContainer>
+      </div>
     )
   }
 )

--- a/src/components/molecules/input/index.tsx
+++ b/src/components/molecules/input/index.tsx
@@ -75,11 +75,7 @@ const InputField = React.forwardRef<HTMLInputElement, InputProps>(
     }
 
     return (
-      <div
-        className={clsx("w-full", className)}
-        onClick={() => !fieldProps.disabled && inputRef?.current?.focus()}
-        {...props}
-      >
+      <div className={clsx("w-full", className)} {...props}>
         {label && (
           <InputHeader
             {...{ label, required, tooltipContent, tooltip }}

--- a/src/components/molecules/input/index.tsx
+++ b/src/components/molecules/input/index.tsx
@@ -131,8 +131,8 @@ const InputField = React.forwardRef<HTMLInputElement, InputProps>(
               </button>
             </div>
           )}
-          <InputError name={name} errors={errors} />
         </div>
+        <InputError name={name} errors={errors} />
       </div>
     )
   }

--- a/src/components/molecules/input/index.tsx
+++ b/src/components/molecules/input/index.tsx
@@ -85,7 +85,14 @@ const InputField = React.forwardRef<HTMLInputElement, InputProps>(
             className="mb-xsmall"
           />
         )}
-        <div className="w-full flex items-center bg-grey-5 border border-gray-20 px-small py-xsmall rounded-rounded h-10 focus-within:shadow-input focus-within:border-violet-60">
+        <div
+          className={clsx(
+            "w-full flex items-center bg-grey-5 border border-gray-20 px-small py-xsmall rounded-rounded h-10 focus-within:shadow-input focus-within:border-violet-60",
+            {
+              "border-rose-50": errors && name && errors[name],
+            }
+          )}
+        >
           {prefix ? (
             <span className="text-grey-40 mr-2xsmall">{prefix}</span>
           ) : null}

--- a/src/components/molecules/modal/index.tsx
+++ b/src/components/molecules/modal/index.tsx
@@ -60,12 +60,6 @@ const Content: React.FC = ({ children }) => {
   )
 }
 
-const addProp = (children, prop) => {
-  return React.Children.map(children, (child) =>
-    React.cloneElement(child, prop)
-  )
-}
-
 const Modal: ModalType = ({
   open = true,
   handleClose,

--- a/src/components/molecules/select/index.tsx
+++ b/src/components/molecules/select/index.tsx
@@ -17,7 +17,6 @@ import ArrowDownIcon from "../../fundamentals/icons/arrow-down-icon"
 import CheckIcon from "../../fundamentals/icons/check-icon"
 import SearchIcon from "../../fundamentals/icons/search-icon"
 import XCircleIcon from "../../fundamentals/icons/x-circle-icon"
-import InputContainer from "../../fundamentals/input-container"
 import InputHeader, { InputHeaderProps } from "../../fundamentals/input-header"
 import { ModalContext } from "../modal"
 
@@ -304,12 +303,8 @@ const SSelect = React.forwardRef(
           "w-full": fullWidth,
         })}
       >
-        <InputContainer
+        <div
           key={name}
-          onFocusLost={() => {
-            setIsFocussed(false)
-            selectRef.current?.blur()
-          }}
           onClick={onClick}
           className={clsx(className, {
             "bg-white rounded-t-rounded": isFocussed,
@@ -318,7 +313,7 @@ const SSelect = React.forwardRef(
           {isFocussed && enableSearch ? (
             <></>
           ) : (
-            <div className="w-full flex text-grey-50 pr-0.5 justify-between pointer-events-none cursor-pointer">
+            <div className="w-full flex text-grey-50 pr-0.5 justify-between pointer-events-none cursor-pointer mb-2">
               <InputHeader {...{ label, required, tooltip, tooltipContent }} />
               <ArrowDownIcon size={16} />
             </div>
@@ -381,7 +376,7 @@ const SSelect = React.forwardRef(
             />
           }
           {isFocussed && enableSearch && <div className="w-full h-5" />}
-        </InputContainer>
+        </div>
       </div>
     )
   }

--- a/src/components/molecules/tag-input/index.tsx
+++ b/src/components/molecules/tag-input/index.tsx
@@ -2,7 +2,6 @@ import clsx from "clsx"
 import React, { useRef, useState } from "react"
 import Tooltip from "../../atoms/tooltip"
 import CrossIcon from "../../fundamentals/icons/cross-icon"
-import InputContainer from "../../fundamentals/input-container"
 import InputHeader from "../../fundamentals/input-header"
 
 const ENTER_KEY = 13
@@ -140,10 +139,6 @@ const TagInput: React.FC<TagInputProps> = ({
     }
   }
 
-  const handleOnContainerFocus = () => {
-    inputRef.current?.focus()
-  }
-
   const handleInput = () => {
     if (!inputRef?.current) {
       return
@@ -158,14 +153,12 @@ const TagInput: React.FC<TagInputProps> = ({
   }
 
   return (
-    <InputContainer
-      className={clsx("flex flex-wrap relative", className)}
-      onFocus={handleOnContainerFocus}
-    >
+    <div className={className}>
       {showLabel && (
         <InputHeader
           label={label || "Tags (comma separated)"}
           {...{ required, tooltipContent, tooltip }}
+          className="mb-2"
         />
       )}
 
@@ -174,42 +167,49 @@ const TagInput: React.FC<TagInputProps> = ({
         side={"top"}
         content={`${inputRef?.current?.value} is not a valid tag`}
       >
-        <div className="w-full gap-x-2 gap-y-1 flex mt-1 ml-0 flex-wrap">
-          {values.map((v, index) => (
-            <div
-              key={index}
-              className={clsx(
-                "items-center justify-center whitespace-nowrap w-max bg-grey-90 rounded",
-                "px-2 leading-6",
-                {
-                  ["bg-grey-70"]: index === highlighted,
-                }
-              )}
-            >
-              <div className="inline-block text-grey-0 h-full inter-small-semibold mr-1">
-                {v}
+        <div className="h-10 bg-grey-5 border border-grey-20 focus-within:shadow-cta focus-within:border-violet-60 rounded-rounded flex items-center px-3 py-[6px]">
+          <div className="w-full gap-x-2 gap-y-1 flex flex-wrap">
+            {values.map((v, index) => (
+              <div
+                key={index}
+                className={clsx(
+                  "flex items-center justify-center whitespace-nowrap w-max bg-grey-20 rounded-rounded px-3 py-1 gap-x-1",
+                  {
+                    ["!bg-grey-90"]: index === highlighted,
+                  }
+                )}
+              >
+                <span
+                  className={clsx(
+                    "inline-block text-grey-50 inter-small-semibold",
+                    {
+                      ["text-grey-20"]: index === highlighted,
+                    }
+                  )}
+                >
+                  {v}
+                </span>
+                <CrossIcon
+                  className="inline cursor-pointer text-grey-40"
+                  size="16"
+                  onClick={() => handleRemove(index)}
+                />
               </div>
-              <CrossIcon
-                className="inline cursor-pointer"
-                size="16"
-                color="#9CA3AF"
-                onClick={() => handleRemove(index)}
-              />
-            </div>
-          ))}
-          <input
-            id="tag-input"
-            ref={inputRef}
-            onBlur={handleBlur}
-            onKeyDown={handleKeyDown}
-            onChange={handleInput}
-            className={clsx("bg-grey-5 focus:outline-none")}
-            placeholder={values?.length ? "" : placeholder} // only visible if no tags exist
-            {...props}
-          />
+            ))}
+            <input
+              id="tag-input"
+              ref={inputRef}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              onChange={handleInput}
+              className={clsx("focus:outline-none bg-transparent flex-1")}
+              placeholder={values?.length ? "" : placeholder} // only visible if no tags exist
+              {...props}
+            />
+          </div>
         </div>
       </Tooltip>
-    </InputContainer>
+    </div>
   )
 }
 

--- a/src/components/molecules/textarea/index.tsx
+++ b/src/components/molecules/textarea/index.tsx
@@ -1,19 +1,20 @@
 import clsx from "clsx"
 import React, { useImperativeHandle, useRef } from "react"
 import InputHeader from "../../fundamentals/input-header"
+import EmojiPicker from "../emoji-picker"
 
-type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+type TextareaProps = React.ComponentPropsWithRef<"textarea"> & {
   label: string
   key?: string
   enableEmoji?: boolean
   withTooltip?: boolean
   tooltipText?: string
   tooltipProps?: any
-  children?: any
+  children?: React.ReactNode
   containerProps?: React.HTMLAttributes<HTMLDivElement>
 }
 
-const TextArea = React.forwardRef(
+const TextArea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
     {
       placeholder,
@@ -33,14 +34,32 @@ const TextArea = React.forwardRef(
     }: TextareaProps,
     ref
   ) => {
-    const inputRef = useRef<HTMLTextAreaElement>(null)
+    const inputRef = useRef<HTMLTextAreaElement | null>(null)
 
-    useImperativeHandle(ref, () => inputRef.current)
+    useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
+      ref,
+      () => inputRef.current
+    )
 
     const scrollToTop = () => {
       if (inputRef.current) {
         inputRef.current.scrollTop = 0
       }
+    }
+
+    const handleAddEmoji = (emoji: string) => {
+      if (!inputRef.current) {
+        return
+      }
+
+      const position = inputRef.current.selectionStart || 0
+
+      const newValue = `${inputRef.current?.value.substring(
+        0,
+        position
+      )}${emoji}${inputRef.current?.value.substring(position)}`
+
+      inputRef.current.value = newValue
     }
 
     return (
@@ -51,7 +70,7 @@ const TextArea = React.forwardRef(
             className="mb-xsmall"
           />
         )}
-        <div className="w-full flex focus-within:shadow-input focus-within:border-violet-60 px-small py-xsmall bg-grey-5 border border-grey-20 rounded-rounded">
+        <div className="w-full flex flex-col focus-within:shadow-input focus-within:border-violet-60 px-small py-xsmall bg-grey-5 border border-grey-20 rounded-rounded">
           <textarea
             className={clsx(
               "relative text-justify overflow-hidden focus:overflow-auto resize-none bg-inherit outline-none outline-0",
@@ -69,11 +88,12 @@ const TextArea = React.forwardRef(
             key={key || name}
             placeholder={placeholder || "Placeholder"}
             onBlur={scrollToTop}
+            onSelect={(e) => {}}
             rows={rows}
             {...props}
           />
+          {enableEmoji && <EmojiPicker onEmojiClick={handleAddEmoji} />}
         </div>
-        {children}
       </div>
     )
   }

--- a/src/components/molecules/textarea/index.tsx
+++ b/src/components/molecules/textarea/index.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx"
 import React, { useImperativeHandle, useRef } from "react"
-import InputContainer from "../../fundamentals/input-container"
 import InputHeader from "../../fundamentals/input-header"
 
 type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
@@ -14,7 +13,7 @@ type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   containerProps?: React.HTMLAttributes<HTMLDivElement>
 }
 
-const Textarea = React.forwardRef(
+const TextArea = React.forwardRef(
   (
     {
       placeholder,
@@ -44,24 +43,15 @@ const Textarea = React.forwardRef(
       }
     }
 
-    const handleAddEmoji = (e) => {
-      console.log(e)
-      console.log(inputRef.current?.selectionStart)
-    }
-
     return (
-      <InputContainer
-        className={className}
-        key={name}
-        onClick={() => inputRef?.current?.focus()}
-        {...containerProps}
-      >
+      <div className={className} {...containerProps}>
         {label && (
           <InputHeader
             {...{ label, required, withTooltip, tooltipText, tooltipProps }}
+            className="mb-xsmall"
           />
         )}
-        <div className="w-full flex mt-1">
+        <div className="w-full flex focus-within:shadow-input focus-within:border-violet-60 px-small py-xsmall bg-grey-5 border border-grey-20 rounded-rounded">
           <textarea
             className={clsx(
               "relative text-justify overflow-hidden focus:overflow-auto resize-none bg-inherit outline-none outline-0",
@@ -84,9 +74,9 @@ const Textarea = React.forwardRef(
           />
         </div>
         {children}
-      </InputContainer>
+      </div>
     )
   }
 )
 
-export default Textarea
+export default TextArea

--- a/src/components/molecules/textarea/textarea.stories.tsx
+++ b/src/components/molecules/textarea/textarea.stories.tsx
@@ -1,14 +1,14 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react"
 import React from "react"
-import Textarea from "."
+import TextArea from "."
 
 export default {
   title: "Molecules/Textarea",
-  component: Textarea,
-} as ComponentMeta<typeof Textarea>
+  component: TextArea,
+} as ComponentMeta<typeof TextArea>
 
-const Template: ComponentStory<typeof Textarea> = (args) => (
-  <Textarea {...args} />
+const Template: ComponentStory<typeof TextArea> = (args) => (
+  <TextArea {...args} />
 )
 
 export const Short = Template.bind({})

--- a/src/components/organisms/help-dialog/index.tsx
+++ b/src/components/organisms/help-dialog/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import Button from "../../fundamentals/button"
 import DiscordIcon from "../../fundamentals/icons/discord-icon"
 import InputField from "../../molecules/input"
-import Textarea from "../../molecules/textarea"
+import TextArea from "../../molecules/textarea"
 
 import * as RadixDropdown from "@radix-ui/react-popover"
 import Picker, { SKIN_TONE_NEUTRAL } from "emoji-picker-react"
@@ -69,7 +69,7 @@ const MailDialog = ({ onDismiss }) => {
           placeholder="What is it about?..."
           onChange={(e) => setSubject(e.target.value)}
         />
-        <Textarea
+        <TextArea
           label={"How can we help?"}
           placeholder="Write a message..."
           value={body}
@@ -86,7 +86,7 @@ const MailDialog = ({ onDismiss }) => {
             onChange={setShowEmojiPicker}
             onEmojiClick={handleAddEmoji}
           />
-        </Textarea>
+        </TextArea>
       </div>
       <div className="flex flex-col items-center">
         <span className="text-grey-40 mb-3">

--- a/src/components/organisms/help-dialog/index.tsx
+++ b/src/components/organisms/help-dialog/index.tsx
@@ -27,7 +27,7 @@ const MailDialog = ({ open, onClose }: MailDialogProps) => {
   return (
     <Dialog.Root open={open} onOpenChange={onClose}>
       <Dialog.Overlay className="fixed z-50 grid top-0 left-0 right-0 bottom-0 place-items-end overflow-y-auto">
-        <Dialog.Content className="bg-grey-0 w-[400px] shadow-dropdown rounded-rounded p-8 top-[64px] bottom-2 right-3 overflow-x-hidden fixed flex flex-col justify-between">
+        <Dialog.Content className="bg-grey-0 w-[400px] shadow-dropdown rounded-rounded p-8 top-[64px] bottom-2 right-3 fixed flex flex-col justify-between">
           <div>
             <Dialog.Title className="inter-xlarge-semibold mb-1">
               How can we help?

--- a/src/components/organisms/help-dialog/index.tsx
+++ b/src/components/organisms/help-dialog/index.tsx
@@ -1,20 +1,20 @@
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import Button from "../../fundamentals/button"
 import DiscordIcon from "../../fundamentals/icons/discord-icon"
 import InputField from "../../molecules/input"
 import TextArea from "../../molecules/textarea"
 
-import * as RadixDropdown from "@radix-ui/react-popover"
-import Picker, { SKIN_TONE_NEUTRAL } from "emoji-picker-react"
-import HappyIcon from "../../fundamentals/icons/happy-icon"
+import * as Dialog from "@radix-ui/react-dialog"
 
-const MailDialog = ({ onDismiss }) => {
+type MailDialogProps = {
+  onClose: () => void
+  open: boolean
+}
+
+const MailDialog = ({ open, onClose }: MailDialogProps) => {
   const [subject, setSubject] = useState("")
   const [body, setBody] = useState("")
-  const [bodySelectionStart, setBodySelectionStart] = useState(0)
   const [link, setLink] = useState("mailto:support@medusajs.com")
-  const ref = React.useRef<HTMLDivElement>(null)
-  const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
 
   React.useEffect(() => {
     setLink(
@@ -24,132 +24,62 @@ const MailDialog = ({ onDismiss }) => {
     )
   }, [subject, body])
 
-  useEffect(() => {
-    console.log(showEmojiPicker)
-  }, [showEmojiPicker])
-
-  React.useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (
-        ref.current &&
-        !ref.current.contains(event.target) &&
-        !showEmojiPicker
-      ) {
-        onDismiss && onDismiss()
-      }
-    }
-    document.addEventListener("click", handleClickOutside, true)
-    return () => {
-      document.removeEventListener("click", handleClickOutside, true)
-    }
-  }, [onDismiss, showEmojiPicker])
-
-  const handleAddEmoji = (e) => {
-    setBody(
-      `${body.slice(0, bodySelectionStart)}${e} ${body.slice(
-        bodySelectionStart
-      )}`
-    )
-  }
-
   return (
-    <div
-      ref={ref}
-      className="bg-grey-0 w-[400px] shadow-dropdown rounded-rounded p-8 top-[64px] bottom-2 right-3 rounded overflow-x-hidden fixed flex flex-col justify-between"
-    >
-      <div>
-        <h1 className="inter-xlarge-semibold mb-1">How can we help?</h1>
-        <h2 className="inter-small-regular text-grey-50 mb-6">
-          We usually respond in a few hours
-        </h2>
-        <InputField
-          label={"Subject"}
-          value={subject}
-          className="mb-4"
-          placeholder="What is it about?..."
-          onChange={(e) => setSubject(e.target.value)}
-        />
-        <TextArea
-          label={"How can we help?"}
-          placeholder="Write a message..."
-          value={body}
-          onSelect={(e) =>
-            setBodySelectionStart(e?.target?.selectionStart || 0)
-          }
-          onChange={(e) => {
-            setBody(e.target.value)
-          }}
-          rows={8}
-        >
-          <EmojiPicker
-            isOpen={showEmojiPicker}
-            onChange={setShowEmojiPicker}
-            onEmojiClick={handleAddEmoji}
-          />
-        </TextArea>
-      </div>
-      <div className="flex flex-col items-center">
-        <span className="text-grey-40 mb-3">
-          <a href="https://discord.gg/medusajs">
-            <DiscordIcon size={24} />
-          </a>
-        </span>
-        <span className="inter-small-regular w-full text-center text-grey-40">
-          Feel free to join a community of
-        </span>
-        <span className="inter-small-regular w-full text-center text-grey-40 mb-7">
-          merchants and e-commerce developers
-        </span>
-        <a className="w-full" href={link}>
-          <Button variant="primary" size="large" className="w-full">
-            Send a message
-          </Button>
-        </a>
-      </div>
-    </div>
-  )
-}
-
-const EmojiPicker = ({ isOpen, onChange, onEmojiClick }) => {
-  return (
-    <RadixDropdown.Root open={isOpen} onOpenChange={(val) => onChange(val)}>
-      <RadixDropdown.Trigger>
-        <Button
-          variant="ghost"
-          size="small"
-          className="focus:border-none focus:shadow-none text-grey-40 hover:text-violet-60 p-0 h-5 w-5"
-        >
-          <HappyIcon size={20} />
-        </Button>
-      </RadixDropdown.Trigger>
-
-      <RadixDropdown.Content
-        sideOffset={5}
-        className="border bg-grey-0 border-grey-20 -translate-x-1/2 rounded-rounded shadow-dropdown min-w-[200px] z-[100]"
-      >
-        <Picker
-          onEmojiClick={(e, data) => {
-            onEmojiClick(data.emoji)
-          }}
-          disableAutoFocus={true}
-          skinTone={SKIN_TONE_NEUTRAL}
-          native
-          disableSkinTonePicker={true}
-          searchPlaceholder={"Search Emoji..."}
-          groupNames={{
-            smileys_people: "Smileys & People",
-            animals_nature: "Animals & Nature",
-            food_drink: "Food & Drink",
-            travel_places: "Travel & Places",
-            activities: "Activities",
-            objects: "Objects",
-            symbols: "Symbols",
-            flags: "Flags",
-            recently_used: "Recently Used",
-          }}
-        />
-      </RadixDropdown.Content>
-    </RadixDropdown.Root>
+    <Dialog.Root open={open} onOpenChange={onClose}>
+      <Dialog.Overlay className="fixed z-50 grid top-0 left-0 right-0 bottom-0 place-items-end overflow-y-auto">
+        <Dialog.Content className="bg-grey-0 w-[400px] shadow-dropdown rounded-rounded p-8 top-[64px] bottom-2 right-3 overflow-x-hidden fixed flex flex-col justify-between">
+          <div>
+            <Dialog.Title className="inter-xlarge-semibold mb-1">
+              How can we help?
+            </Dialog.Title>
+            <Dialog.Description className="inter-small-regular text-grey-50 mb-6">
+              We usually respond in a few hours
+            </Dialog.Description>
+            <InputField
+              label={"Subject"}
+              value={subject}
+              className="mb-4"
+              placeholder="What is it about?..."
+              onChange={(e) => setSubject(e.target.value)}
+            />
+            <TextArea
+              label={"How can we help?"}
+              placeholder="Write a message..."
+              value={body}
+              onChange={(e) => {
+                setBody(e.target.value)
+              }}
+              rows={8}
+              enableEmoji
+            />
+          </div>
+          <div className="flex flex-col items-center gap-y-base">
+            <a
+              href="https://discord.gg/medusajs"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group cursor-pointer w-full"
+            >
+              <div className="flex flex-col items-center justify-center rounded-rounded group-hover:bg-grey-5 w-full py-small">
+                <span className="text-grey-40 mb-3">
+                  <DiscordIcon size={24} />
+                </span>
+                <p className="text-grey-40 inter-small-regular text-center leading-6">
+                  Feel free to join our community of
+                  <br />
+                  merchants and e-commerce developers
+                </p>
+              </div>
+            </a>
+            <a className="w-full" href={link}>
+              <Button variant="primary" size="large" className="w-full">
+                Send a message
+              </Button>
+            </a>
+          </div>
+        </Dialog.Content>
+      </Dialog.Overlay>
+    </Dialog.Root>
   )
 }
 

--- a/src/components/organisms/topbar/index.tsx
+++ b/src/components/organisms/topbar/index.tsx
@@ -91,7 +91,10 @@ const Topbar: React.FC = () => {
         </div>
       </div>
       {showSupportform && (
-        <MailDialog onDismiss={() => setShowSupportForm(false)} />
+        <MailDialog
+          open={showSupportform}
+          onClose={() => setShowSupportForm(false)}
+        />
       )}
       {activityDrawerState && (
         <ActivityDrawer onDismiss={activityDrawerClose} />

--- a/src/domain/discounts/details/general/edit-general.tsx
+++ b/src/domain/discounts/details/general/edit-general.tsx
@@ -6,7 +6,7 @@ import Button from "../../../../components/fundamentals/button"
 import InputField from "../../../../components/molecules/input"
 import Modal from "../../../../components/molecules/modal"
 import Select from "../../../../components/molecules/select"
-import Textarea from "../../../../components/molecules/textarea"
+import TextArea from "../../../../components/molecules/textarea"
 import CurrencyInput from "../../../../components/organisms/currency-input"
 import useNotification from "../../../../hooks/use-notification"
 import { Option } from "../../../../types/shared"
@@ -102,7 +102,7 @@ const EditGeneral: React.FC<EditGeneralProps> = ({ discount, onClose }) => {
                 validate: (value) =>
                   Array.isArray(value) ? value.length > 0 : !!value,
               }}
-              render={({ field: {value, onChange} }) => {
+              render={({ field: { value, onChange } }) => {
                 return (
                   <Select
                     value={value}
@@ -125,7 +125,7 @@ const EditGeneral: React.FC<EditGeneralProps> = ({ discount, onClose }) => {
                 className="flex-1"
                 placeholder="SUMMERSALE10"
                 required
-                {...register("code",{ required: "Code is required" })}
+                {...register("code", { required: "Code is required" })}
               />
 
               {type !== "free_shipping" && (
@@ -167,7 +167,7 @@ const EditGeneral: React.FC<EditGeneralProps> = ({ discount, onClose }) => {
                         type="number"
                         placeholder="10"
                         prefix={"%"}
-                        {...register("value",{
+                        {...register("value", {
                           required: "Percentage is required",
                           valueAsNumber: true,
                         })}
@@ -185,7 +185,7 @@ const EditGeneral: React.FC<EditGeneralProps> = ({ discount, onClose }) => {
               </span>
               <span>Uppercase letters and numbers only.</span>
             </div>
-            <Textarea
+            <TextArea
               label="Description"
               required
               placeholder="Summer Sale 2022"

--- a/src/domain/discounts/new/discount-form/sections/general.tsx
+++ b/src/domain/discounts/new/discount-form/sections/general.tsx
@@ -6,7 +6,7 @@ import Checkbox from "../../../../../components/atoms/checkbox"
 import IconTooltip from "../../../../../components/molecules/icon-tooltip"
 import InputField from "../../../../../components/molecules/input"
 import Select from "../../../../../components/molecules/select"
-import Textarea from "../../../../../components/molecules/textarea"
+import TextArea from "../../../../../components/molecules/textarea"
 import CurrencyInput from "../../../../../components/organisms/currency-input"
 import { useDiscountForm } from "../form/discount-form-context"
 
@@ -133,7 +133,7 @@ const General: React.FC<GeneralProps> = ({ discount }) => {
                       type="number"
                       placeholder="10"
                       prefix={"%"}
-                      {...register("rule.value",{
+                      {...register("rule.value", {
                         required: true,
                         valueAsNumber: true,
                       })}
@@ -151,12 +151,12 @@ const General: React.FC<GeneralProps> = ({ discount }) => {
             </span>
             <span>Uppercase letters and numbers only.</span>
           </div>
-          <Textarea
+          <TextArea
             label="Description"
             required
             placeholder="Summer Sale 2022"
             rows={1}
-            {...register("rule.description",{
+            {...register("rule.description", {
               required: true,
             })}
           />
@@ -164,7 +164,7 @@ const General: React.FC<GeneralProps> = ({ discount }) => {
             <Controller
               name="is_dynamic"
               control={control}
-              render={({ field: { onChange, value } }) => {
+              render={({ field: { onChange, value } }) => {
                 return (
                   <Checkbox
                     label="This is a template discount"

--- a/src/domain/gift-cards/custom-giftcard.tsx
+++ b/src/domain/gift-cards/custom-giftcard.tsx
@@ -5,7 +5,7 @@ import Button from "../../components/fundamentals/button"
 import InputField from "../../components/molecules/input"
 import Modal from "../../components/molecules/modal"
 import Select from "../../components/molecules/select"
-import Textarea from "../../components/molecules/textarea"
+import TextArea from "../../components/molecules/textarea"
 import CurrencyInput from "../../components/organisms/currency-input"
 import useNotification from "../../hooks/use-notification"
 import { getErrorMessage } from "../../utils/error-messages"
@@ -124,7 +124,7 @@ const CustomGiftcard: React.FC<CustomGiftcardProps> = ({ onDismiss }) => {
                 placeholder="lebron@james.com"
                 type="email"
               />
-              <Textarea
+              <TextArea
                 label={"Personal Message"}
                 rows={7}
                 placeholder="Something nice to someone special"

--- a/src/domain/gift-cards/new.tsx
+++ b/src/domain/gift-cards/new.tsx
@@ -12,7 +12,7 @@ import PlusIcon from "../../components/fundamentals/icons/plus-icon"
 import TrashIcon from "../../components/fundamentals/icons/trash-icon"
 import InputField from "../../components/molecules/input"
 import Modal from "../../components/molecules/modal"
-import Textarea from "../../components/molecules/textarea"
+import TextArea from "../../components/molecules/textarea"
 import CurrencyInput from "../../components/organisms/currency-input"
 import useNotification from "../../hooks/use-notification"
 import Medusa from "../../services/api"
@@ -153,7 +153,7 @@ const NewGiftCard = ({ onClose }: NewGiftCardProps) => {
                 placeholder="The best Gift Card"
                 {...register("title", { required: true })}
               />
-              <Textarea
+              <TextArea
                 label="Description"
                 placeholder="The best Gift Card of all time"
                 {...register("description")}

--- a/src/domain/pricing/pricing-form/sections/product-prices.tsx
+++ b/src/domain/pricing/pricing-form/sections/product-prices.tsx
@@ -104,7 +104,7 @@ const ProductPrices = ({
           <div className="mb-2">
             <InputField
               placeholder="Search by name or SKU..."
-              startAdornment={<SearchIcon />}
+              prefix={<SearchIcon />}
               onChange={onChange}
             />
           </div>
@@ -151,7 +151,7 @@ const ProductPrices = ({
           />
         </div>
       )} */}
-      
+
       {showAdd && (
         <AddProductsModal
           onSave={setProducts}

--- a/src/domain/products/product-form/form/product-form-context.tsx
+++ b/src/domain/products/product-form/form/product-form-context.tsx
@@ -49,6 +49,7 @@ export const ProductFormProvider = ({
       ...product,
       images: product?.images || [],
     },
+    criteriaMode: "all",
   })
 
   const resetForm = () => {

--- a/src/domain/products/product-form/sections/general.tsx
+++ b/src/domain/products/product-form/sections/general.tsx
@@ -26,7 +26,12 @@ import { PRODUCT_VIEW } from "../utils/constants"
 
 const General = ({ showViewOptions = true, isEdit = false, product }) => {
   const {
-    form: { register, control, setValue },
+    form: {
+      register,
+      control,
+      setValue,
+      formState: { errors },
+    },
     setViewType,
     viewType,
   } = useProductForm()
@@ -76,6 +81,7 @@ const General = ({ showViewOptions = true, isEdit = false, product }) => {
             label="Name"
             placeholder="Jacket, Sunglasses..."
             required
+            errors={errors}
             {...register("title", {
               required: "Name is required",
               minLength: 1,

--- a/src/domain/products/product-form/sections/general.tsx
+++ b/src/domain/products/product-form/sections/general.tsx
@@ -15,7 +15,7 @@ import Input from "../../../../components/molecules/input"
 import Select from "../../../../components/molecules/select"
 import StatusSelector from "../../../../components/molecules/status-selector"
 import TagInput from "../../../../components/molecules/tag-input"
-import Textarea from "../../../../components/molecules/textarea"
+import TextArea from "../../../../components/molecules/textarea"
 import BodyCard from "../../../../components/organisms/body-card"
 import RadioGroup from "../../../../components/organisms/radio-group"
 import useImperativeDialog from "../../../../hooks/use-imperative-dialog"
@@ -99,7 +99,7 @@ const General = ({ showViewOptions = true, isEdit = false, product }) => {
         </label>
 
         <div className="grid grid-rows-3 grid-cols-2 gap-x-8 gap-y-4 mb-large">
-          <Textarea
+          <TextArea
             id="description"
             label="Description"
             placeholder="Short description of the product..."

--- a/src/domain/products/product-form/sections/general.tsx
+++ b/src/domain/products/product-form/sections/general.tsx
@@ -93,7 +93,10 @@ const General = ({ showViewOptions = true, isEdit = false, product }) => {
             label="Handle"
             placeholder="bathrobe"
             prefix="/"
-            {...register("handle")}
+            errors={errors}
+            {...register("handle", {
+              required: "You can't leave this blank on an existing product",
+            })}
           />
         </div>
         <label

--- a/src/domain/settings/taxes/edit-form.tsx
+++ b/src/domain/settings/taxes/edit-form.tsx
@@ -333,7 +333,7 @@ export const SimpleEditForm = ({ onDismiss, taxRate }: SimpleEditFormProps) => {
           <Input
             disabled
             readOnly
-            startAdornment={<LockIcon size={16} />}
+            prefix={<LockIcon size={16} />}
             tabIndex={-1}
             label="Name"
             placeholder="Default"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,6 +1790,11 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@hookform/error-message@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hookform/error-message/-/error-message-2.0.0.tgz#9b1b037fd816ea9b1531c06aa7fab5f5154aa740"
+  integrity sha512-Y90nHzjgL2MP7GFy75kscdvxrCTjtyxGmOLLxX14nd08OXRIh9lMH/y9Kpdo0p1IPowJBiZMHyueg7p+yrqynQ==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"


### PR DESCRIPTION
**What**

- Updates the look of `<InputField />`, and also improves the typing of the component.
- Updates the look of `<TextArea />`.
- Updates the look of `<TagInput />`
- Temporary update to look of `<Select />`, only so that the height matches the other inputs. We will need to do a bigger revamp of the Select component in a separate PR.

![image](https://user-images.githubusercontent.com/45367945/184648719-5ee2129e-b4c4-4dd1-9be9-f6f0c841ad20.png)
**>> Again note that the look of select is temporary, as it requires a bit of a rework to align with the new design <<**
