### PR TITLE
Feat(admin): Toggle tax inclusivity for price lists

### DIFF
--- a/src/domain/pricing/pricing-form/form/mappers.ts
+++ b/src/domain/pricing/pricing-form/form/mappers.ts
@@ -67,7 +67,6 @@ export const mapFormValuesToCreatePriceList = (
     ends_at: values.ends_at || undefined,
     starts_at: values.starts_at || undefined,
     prices,
-    includes_tax: values.includes_tax || undefined,
   }
 }
 
@@ -83,7 +82,6 @@ export const mapFormValuesToUpdatePriceListDetails = (
     ends_at: values.ends_at,
     starts_at: values.starts_at,
     type: values.type || undefined,
-    includes_tax: values.includes_tax || undefined,
   }
 }
 

--- a/src/domain/pricing/pricing-form/form/mappers.ts
+++ b/src/domain/pricing/pricing-form/form/mappers.ts
@@ -77,8 +77,8 @@ export const mapFormValuesToUpdatePriceListDetails = (
     name: values.name || undefined,
     description: values.description || undefined,
     customer_groups: values.customer_groups
-    ? values.customer_groups.map((cg) => ({ id: cg.value }))
-    : [],
+      ? values.customer_groups.map((cg) => ({ id: cg.value }))
+      : [],
     ends_at: values.ends_at,
     starts_at: values.starts_at,
     type: values.type || undefined,

--- a/src/domain/pricing/pricing-form/form/mappers.ts
+++ b/src/domain/pricing/pricing-form/form/mappers.ts
@@ -33,6 +33,7 @@ export const mapPriceListToFormValues = (
       label: pl.name,
       value: pl.id,
     })),
+    includes_tax: priceList.includes_tax,
   }
 }
 
@@ -66,6 +67,7 @@ export const mapFormValuesToCreatePriceList = (
     ends_at: values.ends_at || undefined,
     starts_at: values.starts_at || undefined,
     prices,
+    includes_tax: values.includes_tax || undefined,
   }
 }
 
@@ -76,11 +78,12 @@ export const mapFormValuesToUpdatePriceListDetails = (
     name: values.name || undefined,
     description: values.description || undefined,
     customer_groups: values.customer_groups
-      ? values.customer_groups.map((cg) => ({ id: cg.value }))
-      : [],
+    ? values.customer_groups.map((cg) => ({ id: cg.value }))
+    : [],
     ends_at: values.ends_at,
     starts_at: values.starts_at,
     type: values.type || undefined,
+    includes_tax: values.includes_tax || undefined,
   }
 }
 

--- a/src/domain/pricing/pricing-form/form/pricing-form-context.tsx
+++ b/src/domain/pricing/pricing-form/form/pricing-form-context.tsx
@@ -23,6 +23,7 @@ const defaultState: PriceListFormValues = {
   starts_at: null,
   prices: null,
   type: PriceListType.SALE,
+  includes_tax: null,
 }
 
 const PriceListFormContext = React.createContext<{

--- a/src/domain/pricing/pricing-form/sections/general.tsx
+++ b/src/domain/pricing/pricing-form/sections/general.tsx
@@ -1,10 +1,13 @@
 import React from "react"
+import { Controller } from "react-hook-form"
+import Switch from "../../../../components/atoms/switch"
+import FeatureToggle from "../../../../components/fundamentals/feature-toggle"
 import InputField from "../../../../components/molecules/input"
 import Accordion from "../../../../components/organisms/accordion"
 import { usePriceListForm } from "../form/pricing-form-context"
 
 const General = () => {
-  const { register } = usePriceListForm()
+  const { control, register } = usePriceListForm()
 
   return (
     <Accordion.Item
@@ -19,14 +22,31 @@ const General = () => {
           label="Name"
           required
           placeholder="B2B, Black Friday..."
-          {...register("name",{ required: "Name is required" })}
+          {...register("name", { required: "Name is required" })}
         />
         <InputField
           label="Description"
           required
           placeholder="For our business partners..."
-          {...register("description",{ required: "Description is required" })}
+          {...register("description", { required: "Description is required" })}
         />
+        <FeatureToggle featureFlag="tax_inclusive_pricing">
+          <div className="mt-3">
+            <div className="flex justify-between">
+              <h2 className="inter-base-semibold">Tax inclusive prices</h2>
+              <Controller
+                control={control}
+                name="includes_tax"
+                render={({ field: { value, onChange } }) => {
+                  return <Switch checked={!!value} onCheckedChange={onChange} />
+                }}
+              />
+            </div>
+            <p className="inter-base-regular text-grey-50">
+              Choose to make all prices in this list inclusive of tax.
+            </p>
+          </div>
+        </FeatureToggle>
       </div>
     </Accordion.Item>
   )

--- a/src/domain/pricing/pricing-form/types/index.ts
+++ b/src/domain/pricing/pricing-form/types/index.ts
@@ -34,6 +34,7 @@ export type PriceListFormValues = {
   customer_groups: Option[] | null
   type: PriceListType | null
   prices: PriceProps[] | null
+  includes_tax: boolean 
 }
 
 export type CreatePriceListPricesFormValues = {
@@ -48,6 +49,7 @@ export type CreatePriceListFormValues = {
   customer_groups: Option[] | null
   type: PriceListType | null
   prices: CreatePriceListPricesFormValues | null
+  includes_tax: boolean 
 }
 
 export type ConfigurationField = keyof Pick<


### PR DESCRIPTION
**What**
- include switch for setting/updating `includes_tax`

**How**
- expand update and create methods in the pricelist form header to set `includes_tax` if feature is enabled, otherwise it wont be set 

Fixes CORE-402