### PR TITLE
fix: amount inputs work with locales that use comma separators

### DIFF
--- a/src/components/organisms/currency-input/index.tsx
+++ b/src/components/organisms/currency-input/index.tsx
@@ -10,7 +10,7 @@ import React, {
 import AmountField from "react-currency-input-field"
 import { Option } from "../../../types/shared"
 import { currencies, CurrencyType } from "../../../utils/currencies"
-import { getDecimalDigits, normalizeAmount } from "../../../utils/prices"
+import { normalizeAmount, persistedPrice } from "../../../utils/prices"
 import InputError from "../../atoms/input-error"
 import Tooltip from "../../atoms/tooltip"
 import MinusIcon from "../../fundamentals/icons/minus-icon"
@@ -173,7 +173,7 @@ const Amount = forwardRef<HTMLInputElement, AmountInputProps>(
   ) => {
     const { currencyInfo } = useContext(CurrencyContext)
     const [invalid, setInvalid] = useState<boolean>(false)
-    const [value, setValue] = useState<string | undefined>(
+    const [formattedValue, setFormattedValue] = useState<string | undefined>(
       amount ? `${normalizeAmount(currencyInfo?.code!, amount)}` : undefined
     )
     const inputRef = useRef<HTMLInputElement | null>(null)
@@ -189,48 +189,78 @@ const Amount = forwardRef<HTMLInputElement, AmountInputProps>(
 
     useEffect(() => {
       if (currencyInfo && amount) {
-        setValue(`${normalizeAmount(currencyInfo?.code, amount)}`)
+        setFormattedValue(`${normalizeAmount(currencyInfo?.code, amount)}`)
       }
     }, [amount])
 
-    const handleChange = (value) => {
+    // const handleChange = (value?: string, floatValue?: number | null) => {
+    //   let persistedAmount: number | undefined = undefined
+
+    //   if (!value) {
+    //     value = 0
+    //   }
+
+    //   if (currencyInfo) {
+    //     const amount = parseFloat(value)
+    //     const multiplier = getDecimalDigits(currencyInfo.code)
+    //     persistedAmount = multiplier * amount
+    //   }
+
+    //   if (onChange && typeof persistedAmount !== "undefined") {
+    //     const updateAmount = Math.round(persistedAmount)
+    //     let update = true
+    //     if (onValidate) {
+    //       update = onValidate(updateAmount)
+    //     }
+
+    //     if (update) {
+    //       onChange(updateAmount)
+    //       setFormattedValue(`${value}`)
+    //       setInvalid(false)
+    //     } else {
+    //       setInvalid(true)
+    //     }
+    //   }
+    // }
+
+    const handleChange = (value?: string, floatValue?: number | null) => {
       let persistedAmount: number | undefined = undefined
 
-      if (!value) {
-        value = 0
+      if (floatValue && currencyInfo) {
+        persistedAmount = Math.round(
+          persistedPrice(currencyInfo.code, floatValue)
+        )
+      } else {
+        persistedAmount = undefined
       }
 
-      if (currencyInfo) {
-        const amount = parseFloat(value)
-        const multiplier = getDecimalDigits(currencyInfo.code)
-        persistedAmount = multiplier * amount
-      }
-
-      if (onChange && typeof persistedAmount !== "undefined") {
-        const updateAmount = Math.round(persistedAmount)
+      if (onChange) {
         let update = true
+
         if (onValidate) {
-          update = onValidate(updateAmount)
+          update = onValidate(persistedAmount)
         }
 
         if (update) {
-          onChange(updateAmount)
-          setValue(`${value}`)
+          onChange(persistedAmount)
           setInvalid(false)
         } else {
           setInvalid(true)
+          return // Don't update the value if it's invalid
         }
       }
+
+      setFormattedValue(value)
     }
 
     const handleManualValueChange = (val: number) => {
-      const newValue = parseFloat(value ?? "0") + val
+      const newValue = parseFloat(formattedValue ?? "0") + val
 
       if (!allowNegative && newValue < 0) {
         return
       }
 
-      handleChange(`${newValue}`)
+      handleChange(`${newValue}`, newValue)
     }
 
     return (
@@ -259,8 +289,10 @@ const Amount = forwardRef<HTMLInputElement, AmountInputProps>(
           <AmountField
             className="bg-transparent outline-none outline-0 w-full remove-number-spinner leading-base text-grey-90 font-normal caret-violet-60 placeholder-grey-40"
             decimalScale={currencyInfo?.decimal_digits}
-            value={value}
-            onValueChange={handleChange}
+            value={formattedValue}
+            onValueChange={(value, _name, values) =>
+              handleChange(value, values?.float)
+            }
             ref={inputRef}
             step={step}
             allowNegativeValue={allowNegative}

--- a/src/components/organisms/currency-input/index.tsx
+++ b/src/components/organisms/currency-input/index.tsx
@@ -193,36 +193,6 @@ const Amount = forwardRef<HTMLInputElement, AmountInputProps>(
       }
     }, [amount])
 
-    // const handleChange = (value?: string, floatValue?: number | null) => {
-    //   let persistedAmount: number | undefined = undefined
-
-    //   if (!value) {
-    //     value = 0
-    //   }
-
-    //   if (currencyInfo) {
-    //     const amount = parseFloat(value)
-    //     const multiplier = getDecimalDigits(currencyInfo.code)
-    //     persistedAmount = multiplier * amount
-    //   }
-
-    //   if (onChange && typeof persistedAmount !== "undefined") {
-    //     const updateAmount = Math.round(persistedAmount)
-    //     let update = true
-    //     if (onValidate) {
-    //       update = onValidate(updateAmount)
-    //     }
-
-    //     if (update) {
-    //       onChange(updateAmount)
-    //       setFormattedValue(`${value}`)
-    //       setInvalid(false)
-    //     } else {
-    //       setInvalid(true)
-    //     }
-    //   }
-    // }
-
     const handleChange = (value?: string, floatValue?: number | null) => {
       let persistedAmount: number | undefined = undefined
 

--- a/src/components/organisms/medusa-price-input/index.tsx
+++ b/src/components/organisms/medusa-price-input/index.tsx
@@ -26,11 +26,12 @@ function MedusaPriceInput(props: MedusaPriceInputProps) {
 
   /** ******** HANDLERS **********/
 
-  const onAmountChange: PriceInputProps["onAmountChange"] = (value) => {
-    if (value) {
-      const numericalValue = Math.round(
-        parseFloat(value) * 10 ** decimal_digits
-      )
+  const onAmountChange: PriceInputProps["onAmountChange"] = (
+    value?: string,
+    floatValue?: number | null
+  ) => {
+    if (floatValue) {
+      const numericalValue = Math.round(floatValue * 10 ** decimal_digits)
       onChange(numericalValue)
     } else {
       onChange(0)

--- a/src/components/organisms/price-input/index.tsx
+++ b/src/components/organisms/price-input/index.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import AmountField from "react-currency-input-field"
-import { CurrencyInputProps } from "react-currency-input-field"
 
 import { CurrencyType } from "../../../utils/currencies"
 
@@ -10,7 +9,7 @@ import { CurrencyType } from "../../../utils/currencies"
 export type PriceInputProps = {
   amount?: string
   currency: CurrencyType
-  onAmountChange: (amount?: string) => void
+  onAmountChange: (amount?: string, floatAmount?: number | null) => void
 }
 
 /**
@@ -27,12 +26,6 @@ function PriceInput(props: PriceInputProps) {
   const rightOffset = 24 + symbol_native.length * 4
   const placeholder = `0.${"0".repeat(decimal_digits)}`
 
-  /** ******** HANDLERS **********/
-
-  const onChange: CurrencyInputProps["onValueChange"] = (value) => {
-    onAmountChange(value)
-  }
-
   return (
     <div className="w-[314px] relative">
       <div className="absolute flex items-center h-full top-0 left-3">
@@ -42,7 +35,9 @@ function PriceInput(props: PriceInputProps) {
       <AmountField
         step={step}
         value={amount}
-        onValueChange={onChange}
+        onValueChange={(value, _name, values) =>
+          onAmountChange(value, values?.float)
+        }
         allowNegativeValue={false}
         placeholder={placeholder}
         decimalScale={decimal_digits}

--- a/src/domain/products/components/prices-form/price-form-input.tsx
+++ b/src/domain/products/components/prices-form/price-form-input.tsx
@@ -23,27 +23,28 @@ const PriceFormInput = ({
     currencyCode.toUpperCase()
   ]
 
-  const [rawValue, setRawValue] = useState<string | undefined>(
-    amount ? `${amount}` : undefined
+  const getFormattedValue = (value: number) => {
+    return `${value / 10 ** decimal_digits}`
+  }
+
+  const [formattedValue, setFormattedValue] = useState<string | undefined>(
+    amount ? getFormattedValue(amount) : undefined
   )
 
   useEffect(() => {
     if (amount) {
-      const value = amount / 10 ** decimal_digits
-      setRawValue(`${value}`)
+      setFormattedValue(getFormattedValue(amount))
     }
   }, [amount, decimal_digits])
 
-  const onAmountChange = (value) => {
-    if (value) {
-      const numericalValue = Math.round(
-        parseFloat(value) * 10 ** decimal_digits
-      )
+  const onAmountChange = (value?: string, floatValue?: number | null) => {
+    if (floatValue) {
+      const numericalValue = Math.round(floatValue * 10 ** decimal_digits)
       onChange(numericalValue)
     } else {
       onChange(0)
     }
-    setRawValue(value)
+    setFormattedValue(value)
   }
 
   const step = 10 ** -decimal_digits
@@ -62,8 +63,10 @@ const PriceFormInput = ({
 
         <AmountField
           step={step}
-          value={rawValue}
-          onValueChange={onAmountChange}
+          value={formattedValue}
+          onValueChange={(value, _name, values) =>
+            onAmountChange(value, values?.float)
+          }
           allowNegativeValue={false}
           placeholder="-"
           decimalScale={decimal_digits}


### PR DESCRIPTION
**What**

- Fixes a bug where cents/fractions were ignored when using the admin dashboard in a browser with a locale that uses commas as the decimal separator.

**How**
- Instead of using `parseFloat` to get the value that should be used to calculate the persisted amount, we instead use the float that is returned as part of the `onChange` function in react-currency-input-field.

Closes #630 

Closes CORE-595