### PR TITLE
feat: allow custom children and styling of TwoStepDelete

### DIFF
--- a/src/components/atoms/two-step-delete/index.tsx
+++ b/src/components/atoms/two-step-delete/index.tsx
@@ -14,10 +14,12 @@ import Tooltip from "../tooltip"
 type Props = {
   onDelete: () => void
   deleting?: boolean
+  className?: string
+  children?: React.ReactNode
 }
 
 const TwoStepDelete = forwardRef<HTMLButtonElement, Props>(
-  ({ onDelete, deleting = false }: Props, ref) => {
+  ({ onDelete, deleting = false, children, className }: Props, ref) => {
     const [armed, setArmed] = useState(false)
     const innerRef = useRef<HTMLButtonElement>(null)
 
@@ -65,19 +67,20 @@ const TwoStepDelete = forwardRef<HTMLButtonElement, Props>(
           },
           {
             "!bg-grey-40 !border-grey-40 !p-1.5": deleting,
-          }
+          },
+          className
         )}
         disabled={deleting}
         onClick={handleTwoStepDelete}
         ref={innerRef}
       >
-        <span
-          className={clsx({
+        <div
+          className={clsx("text-rose-50 inter-small-semibold", {
             hidden: armed || deleting,
           })}
         >
-          <TrashIcon className="text-gray-500" size={20} />
-        </span>
+          {children || <TrashIcon className="text-grey-50" size={20} />}
+        </div>
         <span
           className={clsx("text-white inter-small-semibold", {
             hidden: !armed || deleting,

--- a/src/components/atoms/two-step-delete/two-step-delete.stories.tsx
+++ b/src/components/atoms/two-step-delete/two-step-delete.stories.tsx
@@ -23,3 +23,29 @@ storiesOf("Atoms/TwoStepDelete", module).add("Default", () => {
     </div>
   )
 })
+
+storiesOf("Atoms/TwoStepDelete", module).add("Custom text and style", () => {
+  const [deleting, setDeleting] = useState<boolean>("delete", false)
+
+  const notification = useNotification()
+
+  const fakeDelete = () => {
+    setDeleting(true)
+    setTimeout(() => {
+      setDeleting(false)
+      notification("Success", "Successfully deleted something", "success")
+    }, 3000)
+  }
+
+  return (
+    <div className="w-[322px]">
+      <TwoStepDelete
+        deleting={deleting}
+        onDelete={fakeDelete}
+        className="w-full"
+      >
+        Cancel Order Edit
+      </TwoStepDelete>
+    </div>
+  )
+})


### PR DESCRIPTION
**What**
- Allows passing className and children to the `TwoStepDelete` button.

**How**
- Add `className` as optional prop
- Add optional `children` as optional prop, if no children are passed we render a `TrashIcon` as was done in the initial design.

Closes CORE-487