### PR TITLE
hotfix: prevent error on no regions in store

### DIFF
--- a/src/domain/settings/regions/region-overview/index.tsx
+++ b/src/domain/settings/regions/region-overview/index.tsx
@@ -35,7 +35,7 @@ const RegionOverview = ({ id }: Props) => {
       return
     }
 
-    if (!selectedRegion && regions) {
+    if (!selectedRegion && regions && regions.length > 0) {
       navigate(`/a/settings/regions/${regions[0].id}`, {
         replace: true,
       })


### PR DESCRIPTION
**What**
- Adds check that prevents error if navigating to `settings/regions` when there are no regions in the store.