### PR TITLE
hothix: remove validation from description

### DIFF
--- a/src/domain/products/components/general-form/index.tsx
+++ b/src/domain/products/components/general-form/index.tsx
@@ -88,9 +88,7 @@ const GeneralForm = ({ form, requireHandle = true }: Props) => {
         placeholder="A warm and cozy jacket..."
         rows={3}
         className="mb-small"
-        {...register(path("description"), {
-          pattern: FormValidator.whiteSpaceRule("Description"),
-        })}
+        {...register(path("description"))}
         errors={errors}
       />
       <p className="inter-base-regular text-grey-50">


### PR DESCRIPTION
**What**

- Removes validation of product description input, as it was preventing users from creating multi-line descriptions. 

Closes #710 