### PR TITLE
Add white-space:pre-wrap to product description

### DIFF
--- a/src/domain/products/edit/sections/general/index.tsx
+++ b/src/domain/products/edit/sections/general/index.tsx
@@ -72,7 +72,7 @@ const GeneralSection = ({ product }: Props) => {
           />
         }
       >
-        <p className="inter-base-regular text-grey-50 mt-2">
+        <p className="inter-base-regular text-grey-50 mt-2 whitespace-pre-wrap">
           {product.description}
         </p>
         <ProductTags product={product} />


### PR DESCRIPTION
The paragraph on product description doesn't preserve new lines.
This PR adds `white-space: pre-wrap` css to preserve new lines

Before:
![2022-09-28_17-40](https://user-images.githubusercontent.com/11018707/192825942-5f170e8b-f693-41a4-9408-68c4c113496a.png)

After:
![2022-09-28_17-45](https://user-images.githubusercontent.com/11018707/192825977-53ebfbee-d013-4556-8f61-0209c56d4410.png)

