### PR TITLE
fix: option pill overflow

### DIFF
--- a/src/components/templates/product-table/index.tsx
+++ b/src/components/templates/product-table/index.tsx
@@ -19,8 +19,9 @@ const DEFAULT_PAGE_SIZE_TILE_VIEW = 18
 type ProductTableProps = {}
 
 const defaultQueryProps = {
-  fields: "id,title,type,thumbnail,status,handle",
-  expand: "variants,options,variants.prices,variants.options,collection,tags",
+  fields: "id,title,thumbnail,status,handle,collection_id",
+  expand:
+    "variants,options,variants.prices,variants.options,collection,tags,type",
   is_giftcard: false,
 }
 

--- a/src/domain/products/edit/sections/variants/index.tsx
+++ b/src/domain/products/edit/sections/variants/index.tsx
@@ -136,7 +136,7 @@ const ProductOptions = () => {
           return (
             <div key={i}>
               <div className="bg-grey-30 h-6 w-9 animate-pulse mb-xsmall"></div>
-              <ul className="flex items-center gap-x-1">
+              <ul className="flex flex-wrap items-center gap-1">
                 {Array.from(Array(3)).map((_, j) => (
                   <li key={j}>
                     <div className="text-grey-50 bg-grey-10 h-8 w-12 animate-pulse rounded-rounded">
@@ -158,13 +158,13 @@ const ProductOptions = () => {
         return (
           <div key={option.id}>
             <h3 className="inter-base-semibold mb-xsmall">{option.title}</h3>
-            <ul className="flex items-center gap-x-1">
+            <ul className="flex flex-wrap items-center gap-1">
               {option.values
                 ?.map((val) => val.value)
                 .filter((v, index, self) => self.indexOf(v) === index)
                 .map((v, i) => (
                   <li key={i}>
-                    <div className="text-grey-50 bg-grey-10 inter-small-semibold px-3 py-[6px] rounded-rounded">
+                    <div className="text-grey-50 bg-grey-10 inter-small-semibold px-3 py-[6px] rounded-rounded whitespace-nowrap">
                       {v}
                     </div>
                   </li>


### PR DESCRIPTION
**What**

- Fixes an issue where option pills on the product edit page would overflow.
- Also fixes an issue where query props in ProductTable were wrong, resulting in the collection_id of the products not being returned from the API request.

<img width="827" alt="image" src="https://user-images.githubusercontent.com/45367945/193014930-987a3dc4-2fd2-46bc-8523-c951f337c5cc.png">


Closes CORE-652