### PR TITLE
fix: allow custom shipping price of 0 in swap

### DIFF
--- a/src/components/molecules/rma-select-shipping/index.tsx
+++ b/src/components/molecules/rma-select-shipping/index.tsx
@@ -21,7 +21,7 @@ const RMAShippingPrice: React.FC<RMAShippingPriceProps> = ({
   setUseCustomShippingPrice,
 }) => {
   return useCustomShippingPrice ? (
-    <div className="flex items-end mt-4">
+    <div className="flex items-end mt-4 gap-x-base w-full">
       <AmountInput
         label={`Shipping price (${inclTax ? "incl. tax" : "excl. tax"})`}
         currencyCode={currencyCode}
@@ -30,7 +30,7 @@ const RMAShippingPrice: React.FC<RMAShippingPriceProps> = ({
       />
       <Button
         onClick={() => setUseCustomShippingPrice(false)}
-        className="w-10 h-10 ml-8 text-grey-40"
+        className="w-10 h-10 text-grey-40"
         variant="ghost"
         size="small"
       >

--- a/src/components/molecules/rma-select-shipping/index.tsx
+++ b/src/components/molecules/rma-select-shipping/index.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import Button from "../../fundamentals/button"
 import TrashIcon from "../../fundamentals/icons/trash-icon"
-import CurrencyInput from "../../organisms/currency-input"
+import { AmountInput } from "../amount-input"
 
 type RMAShippingPriceProps = {
   inclTax: boolean
@@ -22,18 +22,12 @@ const RMAShippingPrice: React.FC<RMAShippingPriceProps> = ({
 }) => {
   return useCustomShippingPrice ? (
     <div className="flex items-end mt-4">
-      <CurrencyInput.Root
-        readOnly
-        size="small"
-        currentCurrency={currencyCode}
-        className="w-full"
-      >
-        <CurrencyInput.Amount
-          label={`Amount (${inclTax ? "incl." : "excl."} tax)`}
-          amount={shippingPrice}
-          onChange={updateShippingPrice}
-        />
-      </CurrencyInput.Root>
+      <AmountInput
+        label={`Shipping price (${inclTax ? "incl. tax" : "excl. tax"})`}
+        currencyCode={currencyCode}
+        onChange={(amount) => updateShippingPrice(amount ?? 0)}
+        value={shippingPrice}
+      />
       <Button
         onClick={() => setUseCustomShippingPrice(false)}
         className="w-10 h-10 ml-8 text-grey-40"

--- a/src/domain/orders/details/claim/create.tsx
+++ b/src/domain/orders/details/claim/create.tsx
@@ -193,8 +193,6 @@ const ClaimMenu: React.FC<ClaimMenuProps> = ({ order, onDismiss }) => {
     })
   }, [shippingMethod, showCustomPrice])
 
-  useEffect(() => console.log(shippingAddress), [shippingAddress])
-
   const onSubmit = () => {
     const claim_items = Object.entries(toReturn).map(([key, value]) => {
       return {

--- a/src/domain/orders/details/swap/create.tsx
+++ b/src/domain/orders/details/swap/create.tsx
@@ -338,10 +338,6 @@ const SwapMenu: React.FC<SwapMenuProps> = ({ order, onDismiss }) => {
             </span>
           </div>
           <div className="flex text-grey-90 justify-between items-center inter-small-regular mt-2">
-            <span>Return Shipping</span>
-            <span>{shippingPrice}</span>
-          </div>
-          <div className="flex text-grey-90 justify-between items-center inter-small-regular mt-2">
             <span>Outbond Shipping</span>
             <span>Calculated at checkout</span>
           </div>

--- a/src/domain/orders/details/swap/create.tsx
+++ b/src/domain/orders/details/swap/create.tsx
@@ -151,8 +151,10 @@ const SwapMenu: React.FC<SwapMenuProps> = ({ order, onDismiss }) => {
   }
 
   const handleUpdateShippingPrice = (value: number | undefined) => {
-    if (value && value >= 0) {
+    if (value !== undefined && value >= 0) {
       setShippingPrice(value)
+    } else {
+      setShippingPrice(0)
     }
   }
 
@@ -253,6 +255,7 @@ const SwapMenu: React.FC<SwapMenuProps> = ({ order, onDismiss }) => {
             )}
             {shippingMethod && (
               <RMAShippingPrice
+                inclTax={false}
                 useCustomShippingPrice={useCustomShippingPrice}
                 shippingPrice={shippingPrice}
                 currencyCode={order.currency_code}
@@ -333,6 +336,10 @@ const SwapMenu: React.FC<SwapMenuProps> = ({ order, onDismiss }) => {
                 tax: order.tax_rate ?? undefined,
               })}
             </span>
+          </div>
+          <div className="flex text-grey-90 justify-between items-center inter-small-regular mt-2">
+            <span>Return Shipping</span>
+            <span>{shippingPrice}</span>
           </div>
           <div className="flex text-grey-90 justify-between items-center inter-small-regular mt-2">
             <span>Outbond Shipping</span>


### PR DESCRIPTION
**What**
- Fixes bug that was preventing custom shipping prices from being sent as part of a swap create payload if the price was 0.
- Also if the value of the custom shipping price field is set to `undefined`, but the price is not deleted using the `delete` button, it will be interpreted as meaning that the cost of return shipping should be 0.

Closes CORE-569