### PR TITLE
Fix(medusa): prevent showing protected routes when loading unauthenticated admin

### DIFF
--- a/src/components/private-route/index.js
+++ b/src/components/private-route/index.js
@@ -18,7 +18,7 @@ const PrivateRoute = ({ component: Component, location, ...rest }) => {
       })
   }, [])
 
-  if (account.isLoggedIn) {
+  if (account.isLoggedIn && !loading) {
     return <Component {...rest} />
   }
 

--- a/src/components/private-route/index.js
+++ b/src/components/private-route/index.js
@@ -1,14 +1,13 @@
 import { navigate } from "gatsby"
 import React, { useContext, useState } from "react"
 import { AccountContext } from "../../context/account"
+import Spinner from "../atoms/spinner"
 
 const PrivateRoute = ({ component: Component, location, ...rest }) => {
-  const [loading, setLoading] = useState(false)
   const account = useContext(AccountContext)
+  const [loading, setLoading] = useState(true)
 
-  if (account.isLoggedIn) {
-    return <Component {...rest} />
-  } else if (!loading) {
+  React.useEffect(() => {
     account
       .session()
       .then((data) => {
@@ -17,8 +16,17 @@ const PrivateRoute = ({ component: Component, location, ...rest }) => {
       .catch((err) => {
         navigate("/login")
       })
+  }, [])
+
+  if (account.isLoggedIn) {
+    return <Component {...rest} />
   }
-  return "Loading..."
+
+  return (
+    <div className="h-screen w-full flex items-center justify-center">
+      <Spinner variant="secondary" />
+    </div>
+  )
 }
 
 export default PrivateRoute

--- a/src/pages/a.js
+++ b/src/pages/a.js
@@ -32,17 +32,17 @@ const Routes = () => {
       <Layout>
         <SEO title="Medusa" />
         <Router basepath="a" className="h-full">
-          <PrivateRoute path="oauth/:app_name" component={Oauth} />
-          <PrivateRoute path="products/*" component={ProductsRoute} />
-          <PrivateRoute path="collections/*" component={Collections} />
-          <PrivateRoute path="gift-cards/*" component={GiftCards} />
-          <PrivateRoute path="orders/*" component={Orders} />
-          <PrivateRoute path="draft-orders/*" component={DraftOrders} />
-          <PrivateRoute path="discounts/*" component={Discounts} />
-          <PrivateRoute path="customers/*" component={Customers} />
-          <PrivateRoute path="pricing/*" component={Pricing} />
-          <PrivateRoute path="settings/*" component={Settings} />
-          <PrivateRoute path="sales-channels/*" component={SalesChannels} />
+          <Oauth path="oauth/:app_name"/>
+          <ProductsRoute path="products/*"/>
+          <Collections path="collections/*"/>
+          <GiftCards path="gift-cards/*" />
+          <Orders path="orders/*" />
+          <DraftOrders path="draft-orders/*" />
+          <Discounts path="discounts/*"/>
+          <Customers path="customers/*"/>
+          <Pricing path="pricing/*"/>
+          <Settings path="settings/*"/>
+          <SalesChannels path="sales-channels/*" />
         </Router>
       </Layout>
     </DndProvider>

--- a/src/pages/a.js
+++ b/src/pages/a.js
@@ -22,6 +22,11 @@ import Settings from "../domain/settings"
 const IndexPage = () => {
   useHotkeys("g + o", () => navigate("/a/orders"))
   useHotkeys("g + p", () => navigate("/a/products"))
+
+  return <PrivateRoute component={Routes} />
+}
+
+const Routes = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <Layout>


### PR DESCRIPTION
**What**
- prevent showing the layout in a flash before the login screen when navigating unauthenticated to a page under `/a/*`

**How**
- wrap the components in `pages/a` in a `privateRoute` 

Fixes CORE-439