### PR TITLE
fix: OE UI polish

### DIFF
--- a/src/components/molecules/timeline-events/exchange.tsx
+++ b/src/components/molecules/timeline-events/exchange.tsx
@@ -5,7 +5,9 @@ import {
   useAdminReceiveReturn,
   useAdminStore,
 } from "medusa-react"
+import { ReturnItem } from "@medusajs/medusa"
 import React, { useEffect, useState } from "react"
+
 import CreateFulfillmentModal from "../../../domain/orders/details/create-fulfillment"
 import ReceiveMenu from "../../../domain/orders/details/returns/receive-menu"
 import { ExchangeEvent } from "../../../hooks/use-build-timeline"
@@ -318,9 +320,13 @@ function getReturnItems(event: ExchangeEvent) {
     <div className="flex flex-col gap-y-small">
       <span className="inter-small-regular text-grey-50">Return Items</span>
       <div>
-        {event.returnItems.map((i) => (
-          <EventItemContainer item={{ ...i, quantity: i.requestedQuantity }} />
-        ))}
+        {event.returnItems
+          .filter((i) => !!i)
+          .map((i: ReturnItem) => (
+            <EventItemContainer
+              item={{ ...i, quantity: i.requestedQuantity }}
+            />
+          ))}
       </div>
     </div>
   )

--- a/src/components/molecules/timeline-events/order-edit/canceled.tsx
+++ b/src/components/molecules/timeline-events/order-edit/canceled.tsx
@@ -2,7 +2,6 @@ import { useAdminUser } from "medusa-react"
 import React from "react"
 import { ByLine } from "."
 import { OrderEditEvent } from "../../../../hooks/use-build-timeline"
-import Avatar from "../../../atoms/avatar"
 import XCircleIcon from "../../../fundamentals/icons/x-circle-icon"
 import EventContainer from "../event-container"
 

--- a/src/components/molecules/timeline-events/order-edit/confirmed-difference-due.tsx
+++ b/src/components/molecules/timeline-events/order-edit/confirmed-difference-due.tsx
@@ -18,13 +18,16 @@ const EditConfirmedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
   })
 
   const [showRefundModal, setShowRefundModal] = useState(false)
+
   if (
     !event.isLastConfirmed ||
     !order ||
-    (order && order.total >= order.paid_total)
+    (order && order.paid_total - order.refunded_total - order.total > 0)
   ) {
     return null
   }
+
+  const refundableAmount = order.paid_total - order.refunded_total - order.total
 
   return (
     <>
@@ -34,14 +37,6 @@ const EditConfirmedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
         iconColor={EventIconColor.RED}
         time={event.time}
         isFirst={event.first}
-        // midNode={
-        //   <span className="inter-small-regular text-grey-50">
-        //     {formatAmountWithSymbol({
-        //       amount: orderEdit.difference_due,
-        //       currency: event.currency_code,
-        //     })}
-        //   </span>
-        // }
       >
         <Button
           onClick={() => setShowRefundModal(true)}
@@ -51,7 +46,7 @@ const EditConfirmedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
         >
           Refund
           {formatAmountWithSymbol({
-            amount: Math.abs(order?.total - order?.paid_total),
+            amount: refundableAmount,
             currency: event.currency_code,
           })}
         </Button>
@@ -59,7 +54,7 @@ const EditConfirmedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
       {showRefundModal && (
         <CreateRefundModal
           order={order}
-          initialAmount={order.paid_total - order.total}
+          initialAmount={refundableAmount}
           initialReason="other"
           onDismiss={() => setShowRefundModal(false)}
         />

--- a/src/components/molecules/timeline-events/order-edit/confirmed-difference-due.tsx
+++ b/src/components/molecules/timeline-events/order-edit/confirmed-difference-due.tsx
@@ -19,7 +19,7 @@ const EditConfirmedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
 
   return (
     <EventContainer
-      title={"Refund reqired"}
+      title={"Refund required"}
       icon={<AlertIcon size={20} />}
       iconColor={EventIconColor.RED}
       time={event.time}

--- a/src/components/molecules/timeline-events/order-edit/created.tsx
+++ b/src/components/molecules/timeline-events/order-edit/created.tsx
@@ -7,7 +7,7 @@ import {
   useAdminRequestOrderEditConfirmation,
   useAdminUser,
 } from "medusa-react"
-import React from "react"
+import React, { useContext } from "react"
 import { ByLine } from "."
 import { OrderEditEvent } from "../../../../hooks/use-build-timeline"
 import useImperativeDialog from "../../../../hooks/use-imperative-dialog"
@@ -18,6 +18,7 @@ import Button from "../../../fundamentals/button"
 import EditIcon from "../../../fundamentals/icons/edit-icon"
 import ImagePlaceholder from "../../../fundamentals/image-placeholder"
 import EventContainer from "../event-container"
+import { OrderEditContext } from "../../../../domain/orders/edit/context"
 
 type EditCreatedProps = {
   event: OrderEditEvent
@@ -43,6 +44,9 @@ const getInfo = (edit: OrderEdit): { type: string; user_id: string } => {
 }
 
 const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
+  const { isModalVisible, showModal, setActiveOrderEdit } = useContext(
+    OrderEditContext
+  )
   const { type, user_id } = getInfo(event.edit)
 
   const { order_edit: orderEdit } = useAdminOrderEdit(event.edit.id)
@@ -57,7 +61,6 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
 
   const deleteOrderEdit = useAdminDeleteOrderEdit(event.edit.id)
   const cancelOrderEdit = useAdminCancelOrderEdit(event.edit.id)
-  const requestOrderEdit = useAdminRequestOrderEditConfirmation(event.edit.id)
   const confirmOrderEdit = useAdminConfirmOrderEdit(event.edit.id)
 
   const onDeleteOrderEditClicked = () => {
@@ -107,19 +110,17 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
     }
   }
 
+  const onContinueEdit = () => {
+    setActiveOrderEdit(orderEdit.id)
+    showModal()
+  }
+
   const onCopyConfirmationLinkClicked = () => {
     console.log("TODO")
   }
 
-  const onRequestOrderEditClicked = () => {
-    requestOrderEdit.mutate(undefined, {
-      onSuccess: () => {
-        notification("Success", `Successfully requested Order Edit`, "success")
-      },
-      onError: (err) => {
-        notification("Error", getErrorMessage(err), "error")
-      },
-    })
+  if (isModalVisible) {
+    return null
   }
 
   return (
@@ -142,40 +143,25 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
         {(event.edit.status === "created" ||
           event.edit.status === "requested") && (
           <div className="space-y-xsmall mt-large">
-            {type === "created" && (
-              <Button
-                className="w-full border border-grey-20"
-                size="small"
-                variant="ghost"
-                onClick={onRequestOrderEditClicked}
-              >
-                Send Confirmation-Request
-              </Button>
-            )}
-            <Button
-              className="w-full border border-grey-20"
-              size="small"
-              variant="ghost"
-              onClick={onCopyConfirmationLinkClicked}
-            >
-              Copy Confirmation-Request Link
-            </Button>
-            <Button
-              className="w-full border border-grey-20"
-              size="small"
-              variant="ghost"
-              onClick={onConfirmEditClicked}
-            >
-              Force Confirm
-            </Button>
-
             {type === "created" ? (
-              <TwoStepDelete
-                onDelete={onDeleteOrderEditClicked}
-                className="w-full border border-grey-20"
-              >
-                Delete Order Edit
-              </TwoStepDelete>
+              <>
+                <Button
+                  className="w-full border border-grey-20"
+                  size="small"
+                  variant="ghost"
+                  onClick={onContinueEdit}
+                >
+                  Continue order edit
+                </Button>
+                <Button
+                  className="w-full border border-grey-20"
+                  size="small"
+                  variant="danger"
+                  onClick={onDeleteOrderEditClicked}
+                >
+                  Delete the order edit
+                </Button>
+              </>
             ) : (
               <TwoStepDelete
                 onDelete={onCancelOrderEditClicked}

--- a/src/components/molecules/timeline-events/order-edit/created.tsx
+++ b/src/components/molecules/timeline-events/order-edit/created.tsx
@@ -1,7 +1,6 @@
 import { LineItem, OrderEdit, OrderItemChange } from "@medusajs/medusa"
 import {
   useAdminCancelOrderEdit,
-  useAdminConfirmOrderEdit,
   useAdminDeleteOrderEdit,
   useAdminOrderEdit,
   useAdminUser,
@@ -9,7 +8,6 @@ import {
 import React, { useContext } from "react"
 import { ByLine } from "."
 import { OrderEditEvent } from "../../../../hooks/use-build-timeline"
-import useImperativeDialog from "../../../../hooks/use-imperative-dialog"
 import useNotification from "../../../../hooks/use-notification"
 import { getErrorMessage } from "../../../../utils/error-messages"
 import TwoStepDelete from "../../../atoms/two-step-delete"
@@ -18,6 +16,7 @@ import EditIcon from "../../../fundamentals/icons/edit-icon"
 import ImagePlaceholder from "../../../fundamentals/image-placeholder"
 import EventContainer from "../event-container"
 import { OrderEditContext } from "../../../../domain/orders/edit/context"
+import CopyToClipboard from "../../../atoms/copy-to-clipboard"
 
 type EditCreatedProps = {
   event: OrderEditEvent
@@ -224,9 +223,7 @@ const OrderEditChangeItem: React.FC<OrderEditChangeItemProps> = ({
         <span className="inter-small-semibold text-grey-90">
           {quantity > 1 && <>{quantity}x</>} {lineItem?.title} &nbsp;
           {lineItem?.variant?.sku && (
-            <span className="inter-small-regular text-grey-50">
-              ({lineItem.variant?.sku})
-            </span>
+            <CopyToClipboard value={lineItem?.variant?.sku} iconSize={14} />
           )}
         </span>
         <span className="flex inter-small-regular text-grey-50">

--- a/src/components/molecules/timeline-events/order-edit/created.tsx
+++ b/src/components/molecules/timeline-events/order-edit/created.tsx
@@ -56,11 +56,8 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
 
   const { user } = useAdminUser(user_id)
 
-  const forceConfirmDialog = useImperativeDialog()
-
   const deleteOrderEdit = useAdminDeleteOrderEdit(event.edit.id)
   const cancelOrderEdit = useAdminCancelOrderEdit(event.edit.id)
-  const confirmOrderEdit = useAdminConfirmOrderEdit(event.edit.id)
 
   const onDeleteOrderEditClicked = () => {
     deleteOrderEdit.mutate(undefined, {
@@ -89,7 +86,8 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
     showModal()
   }
 
-  if (isModalVisible) {
+  // hide last created edit while editing
+  if (isModalVisible && orderEdit?.status === "created") {
     return null
   }
 
@@ -224,7 +222,7 @@ const OrderEditChangeItem: React.FC<OrderEditChangeItemProps> = ({
       </div>
       <div className="flex flex-col">
         <span className="inter-small-semibold text-grey-90">
-          {quantity > 1 && <>{quantity}x</>} {lineItem?.title}
+          {quantity > 1 && <>{quantity}x</>} {lineItem?.title} &nbsp;
           {lineItem?.variant?.sku && (
             <span className="inter-small-regular text-grey-50">
               ({lineItem.variant?.sku})

--- a/src/components/molecules/timeline-events/order-edit/created.tsx
+++ b/src/components/molecules/timeline-events/order-edit/created.tsx
@@ -153,14 +153,12 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
                 >
                   Continue order edit
                 </Button>
-                <Button
+                <TwoStepDelete
+                  onDelete={onDeleteOrderEditClicked}
                   className="w-full border border-grey-20"
-                  size="small"
-                  variant="danger"
-                  onClick={onDeleteOrderEditClicked}
                 >
                   Delete the order edit
-                </Button>
+                </TwoStepDelete>
               </>
             ) : (
               <TwoStepDelete

--- a/src/components/molecules/timeline-events/order-edit/created.tsx
+++ b/src/components/molecules/timeline-events/order-edit/created.tsx
@@ -47,7 +47,7 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
   )
   const { type, user_id } = getInfo(event.edit)
 
-  const { order_edit: orderEdit } = useAdminOrderEdit(event.edit.id)
+  const { order_edit: orderEdit, isFetching } = useAdminOrderEdit(event.edit.id)
 
   const notification = useNotification()
 
@@ -85,8 +85,8 @@ const EditCreated: React.FC<EditCreatedProps> = ({ event }) => {
     showModal()
   }
 
-  // hide last created edit while editing
-  if (isModalVisible && orderEdit?.status === "created") {
+  // hide last created edit while editing and prevent content flashing while loading
+  if ((isModalVisible && orderEdit?.status === "created") || isFetching) {
     return null
   }
 

--- a/src/components/molecules/timeline-events/order-edit/index.tsx
+++ b/src/components/molecules/timeline-events/order-edit/index.tsx
@@ -2,14 +2,26 @@ import React from "react"
 import Avatar from "../../../atoms/avatar"
 
 type ByLineProps = {
-  user: { first_name: string; last_name: string; email: string }
+  user?: { first_name: string; last_name: string; email: string }
 }
-export const ByLine: React.FC<ByLineProps> = ({ user }) => (
-  <div className="flex inter-small-regular items-center text-grey-50">
-    By
-    <span className="w-base h-base mx-xsmall">
-      <Avatar user={user} font="inter-xsmall-semibold" />
-    </span>
-    {`${user?.first_name || ""} ${user?.last_name || ""}`}
-  </div>
-)
+
+export const ByLine: React.FC<ByLineProps> = ({ user }) => {
+  if (!user) {
+    return null
+  }
+
+  const { first_name, last_name, email } = user
+
+  const by =
+    !first_name && !last_name ? email : `${first_name || ""} ${last_name || ""}`
+
+  return (
+    <div className="flex inter-small-regular items-center text-grey-50">
+      By
+      <span className="w-base h-base mx-xsmall">
+        <Avatar user={user} font="inter-xsmall-semibold" />
+      </span>
+      {by}
+    </div>
+  )
+}

--- a/src/components/molecules/timeline-events/order-edit/refund-difference-due.tsx
+++ b/src/components/molecules/timeline-events/order-edit/refund-difference-due.tsx
@@ -1,6 +1,7 @@
-import { useAdminOrder, useAdminOrderEdit } from "medusa-react"
+import { useAdminOrder } from "medusa-react"
 import React, { useState } from "react"
-import { OrderEditDifferenceDueEvent } from "../../../../hooks/use-build-timeline"
+
+import { RefundDifferenceDueEvent } from "../../../../hooks/use-build-timeline"
 import { formatAmountWithSymbol } from "../../../../utils/prices"
 import Button from "../../../fundamentals/button"
 import AlertIcon from "../../../fundamentals/icons/alert-icon"
@@ -8,21 +9,17 @@ import EventContainer, { EventIconColor } from "../event-container"
 import CreateRefundModal from "../../../../domain/orders/details/refund"
 
 type RequestedProps = {
-  event: OrderEditDifferenceDueEvent
+  event: RefundDifferenceDueEvent
 }
 
-const EditConfirmedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
-  const { order_edit: orderEdit } = useAdminOrderEdit(event.edit.id)
-  const { order } = useAdminOrder(orderEdit?.order_id!, undefined, {
-    enabled: !!orderEdit?.order_id,
-  })
+const RefundDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
+  const { order } = useAdminOrder(event.orderId)
 
   const [showRefundModal, setShowRefundModal] = useState(false)
 
   if (
-    !event.isLastConfirmed ||
     !order ||
-    (order && order.paid_total - order.refunded_total - order.total > 0)
+    (order && order.paid_total - order.refunded_total - order.total <= 0)
   ) {
     return null
   }
@@ -63,4 +60,4 @@ const EditConfirmedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
   )
 }
 
-export default EditConfirmedDifferenceDue
+export default RefundDifferenceDue

--- a/src/components/molecules/timeline-events/order-edit/requested-difference-due.tsx
+++ b/src/components/molecules/timeline-events/order-edit/requested-difference-due.tsx
@@ -13,7 +13,7 @@ type RequestedProps = {
 const EditRequestedDifferenceDue: React.FC<RequestedProps> = ({ event }) => {
   const { order_edit: orderEdit } = useAdminOrderEdit(event.edit.id)
 
-  if (!orderEdit || orderEdit.difference_due < 0) {
+  if (!orderEdit || orderEdit.difference_due <= 0) {
     return null
   }
 

--- a/src/components/molecules/timeline-events/order-edit/requested-difference-due.tsx
+++ b/src/components/molecules/timeline-events/order-edit/requested-difference-due.tsx
@@ -1,5 +1,6 @@
 import { useAdminOrderEdit } from "medusa-react"
 import React from "react"
+
 import { OrderEditDifferenceDueEvent } from "../../../../hooks/use-build-timeline"
 import { formatAmountWithSymbol } from "../../../../utils/prices"
 import Button from "../../../fundamentals/button"

--- a/src/components/molecules/timeline-events/order-edit/requested.tsx
+++ b/src/components/molecules/timeline-events/order-edit/requested.tsx
@@ -31,18 +31,15 @@ const EditRequested: React.FC<RequestedProps> = ({ event }) => {
   }
 
   return (
-    <>
-      <EventContainer
-        title={"Order Edit confirmation-request sent"}
-        icon={<MailIcon size={20} />}
-        time={event.time}
-        isFirst={event.first}
-        midNode={
-          <span className="inter-small-regular text-grey-50">
-            {event.email}
-          </span>
-        }
-      />
+    <EventContainer
+      title={"Order Edit confirmation-request sent"}
+      icon={<MailIcon size={20} />}
+      time={event.time}
+      isFirst={event.first}
+      midNode={
+        <span className="inter-small-regular text-grey-50">{event.email}</span>
+      }
+    >
       {isRequested && (
         <Button
           className="w-full border border-grey-20 mb-5"
@@ -53,7 +50,7 @@ const EditRequested: React.FC<RequestedProps> = ({ event }) => {
           Resend Confirmation-Request
         </Button>
       )}
-    </>
+    </EventContainer>
   )
 }
 

--- a/src/components/molecules/timeline-events/order-edit/requested.tsx
+++ b/src/components/molecules/timeline-events/order-edit/requested.tsx
@@ -1,23 +1,59 @@
 import React from "react"
+
 import { OrderEditRequestedEvent } from "../../../../hooks/use-build-timeline"
 import MailIcon from "../../../fundamentals/icons/mail-icon"
 import EventContainer from "../event-container"
+import useNotification from "../../../../hooks/use-notification"
+import { getErrorMessage } from "../../../../utils/error-messages"
+import { useAdminRequestOrderEditConfirmation } from "medusa-react"
+import Button from "../../../fundamentals/button"
 
 type RequestedProps = {
   event: OrderEditRequestedEvent
 }
 
 const EditRequested: React.FC<RequestedProps> = ({ event }) => {
+  const isRequested = event.edit?.status === "requested"
+
+  const notification = useNotification()
+
+  const requestOrderEdit = useAdminRequestOrderEditConfirmation(event.edit?.id)
+
+  const onRequestOrderEditClicked = () => {
+    requestOrderEdit.mutate(undefined, {
+      onSuccess: () => {
+        notification("Success", `Successfully requested Order Edit`, "success")
+      },
+      onError: (err) => {
+        notification("Error", getErrorMessage(err), "error")
+      },
+    })
+  }
+
   return (
-    <EventContainer
-      title={"Order Edit confirmation-request sent"}
-      icon={<MailIcon size={20} />}
-      time={event.time}
-      isFirst={event.first}
-      midNode={
-        <span className="inter-small-regular text-grey-50">{event.email}</span>
-      }
-    />
+    <>
+      <EventContainer
+        title={"Order Edit confirmation-request sent"}
+        icon={<MailIcon size={20} />}
+        time={event.time}
+        isFirst={event.first}
+        midNode={
+          <span className="inter-small-regular text-grey-50">
+            {event.email}
+          </span>
+        }
+      />
+      {isRequested && (
+        <Button
+          className="w-full border border-grey-20 mb-5"
+          size="small"
+          variant="ghost"
+          onClick={onRequestOrderEditClicked}
+        >
+          Resend Confirmation-Request
+        </Button>
+      )}
+    </>
   )
 }
 

--- a/src/components/molecules/timeline-events/order-edit/requested.tsx
+++ b/src/components/molecules/timeline-events/order-edit/requested.tsx
@@ -1,56 +1,61 @@
-import React from "react"
+import React, { useState } from "react"
+import { useAdminNotifications } from "medusa-react"
 
 import { OrderEditRequestedEvent } from "../../../../hooks/use-build-timeline"
 import MailIcon from "../../../fundamentals/icons/mail-icon"
 import EventContainer from "../event-container"
-import useNotification from "../../../../hooks/use-notification"
-import { getErrorMessage } from "../../../../utils/error-messages"
-import { useAdminRequestOrderEditConfirmation } from "medusa-react"
 import Button from "../../../fundamentals/button"
+import ResendModal from "../notification/resend-modal"
 
 type RequestedProps = {
   event: OrderEditRequestedEvent
 }
 
 const EditRequested: React.FC<RequestedProps> = ({ event }) => {
-  const isRequested = event.edit?.status === "requested"
+  const [showResend, setShowResend] = useState(false)
 
-  const notification = useNotification()
+  const { notifications } = useAdminNotifications({
+    resource_id: event.edit?.id,
+  })
 
-  const requestOrderEdit = useAdminRequestOrderEditConfirmation(event.edit?.id)
+  const notification = notifications?.find(
+    (n) => n.event_name === "order-edit.requested"
+  )
 
-  const onRequestOrderEditClicked = () => {
-    requestOrderEdit.mutate(undefined, {
-      onSuccess: () => {
-        notification("Success", `Successfully requested Order Edit`, "success")
-      },
-      onError: (err) => {
-        notification("Error", getErrorMessage(err), "error")
-      },
-    })
+  if (!notification) {
+    return null
   }
 
   return (
-    <EventContainer
-      title={"Order Edit confirmation-request sent"}
-      icon={<MailIcon size={20} />}
-      time={event.time}
-      isFirst={event.first}
-      midNode={
-        <span className="inter-small-regular text-grey-50">{event.email}</span>
-      }
-    >
-      {isRequested && (
+    <>
+      <EventContainer
+        title={"Order Edit confirmation-request sent"}
+        icon={<MailIcon size={20} />}
+        time={event.time}
+        isFirst={event.first}
+        midNode={
+          <span className="inter-small-regular text-grey-50">
+            {event.email}
+          </span>
+        }
+      >
         <Button
           className="w-full border border-grey-20 mb-5"
           size="small"
           variant="ghost"
-          onClick={onRequestOrderEditClicked}
+          onClick={() => setShowResend(true)}
         >
           Resend Confirmation-Request
         </Button>
+      </EventContainer>
+      {showResend && (
+        <ResendModal
+          handleCancel={() => setShowResend(false)}
+          notificationId={notification.id}
+          email={notification.to}
+        />
       )}
-    </EventContainer>
+    </>
   )
 }
 

--- a/src/components/organisms/timeline/index.tsx
+++ b/src/components/organisms/timeline/index.tsx
@@ -17,7 +17,7 @@ import {
   RefundEvent,
   ReturnEvent,
   TimelineEvent,
-  useBuildTimelime,
+  useBuildTimeline,
   OrderEditRequestedEvent,
   OrderEditDifferenceDueEvent,
 } from "../../../hooks/use-build-timeline"
@@ -54,7 +54,7 @@ type TimelineProps = {
 const Timeline: React.FC<TimelineProps> = ({ orderId }) => {
   const { orderRelations } = useOrdersExpandParam()
 
-  const { events, refetch } = useBuildTimelime(orderId)
+  const { events, refetch } = useBuildTimeline(orderId)
   const notification = useNotification()
   const createNote = useAdminCreateNote()
   const { order } = useAdminOrder(orderId, {

--- a/src/components/organisms/timeline/index.tsx
+++ b/src/components/organisms/timeline/index.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx"
 import { useAdminCreateNote, useAdminOrder } from "medusa-react"
 import React, { useState } from "react"
+
 import ClaimMenu from "../../../domain/orders/details/claim/create"
 import ReturnMenu from "../../../domain/orders/details/returns"
 import SwapMenu from "../../../domain/orders/details/swap/create"
@@ -19,6 +20,7 @@ import {
   TimelineEvent,
   useBuildTimeline,
   OrderEditRequestedEvent,
+  RefundDifferenceDueEvent,
   OrderEditDifferenceDueEvent,
 } from "../../../hooks/use-build-timeline"
 import useNotification from "../../../hooks/use-notification"
@@ -38,7 +40,6 @@ import Notification from "../../molecules/timeline-events/notification"
 import OrderCanceled from "../../molecules/timeline-events/order-canceled"
 import EditCanceled from "../../molecules/timeline-events/order-edit/canceled"
 import EditConfirmed from "../../molecules/timeline-events/order-edit/confirmed"
-import EditConfirmedDifferenceDue from "../../molecules/timeline-events/order-edit/confirmed-difference-due"
 import EditCreated from "../../molecules/timeline-events/order-edit/created"
 import EditDeclined from "../../molecules/timeline-events/order-edit/declined"
 import EditRequested from "../../molecules/timeline-events/order-edit/requested"
@@ -46,6 +47,7 @@ import EditRequestedDifferenceDue from "../../molecules/timeline-events/order-ed
 import OrderPlaced from "../../molecules/timeline-events/order-placed"
 import Refund from "../../molecules/timeline-events/refund"
 import Return from "../../molecules/timeline-events/return"
+import RefundDifferenceDue from "../../molecules/timeline-events/order-edit/refund-difference-due"
 
 type TimelineProps = {
   orderId: string
@@ -183,12 +185,8 @@ function switchOnType(event: TimelineEvent, refetch: () => void) {
       return <EditConfirmed event={event as OrderEditEvent} />
     case "edit-requested":
       return <EditRequested event={event as OrderEditRequestedEvent} />
-    case "edit-confirmed-difference-due":
-      return (
-        <EditConfirmedDifferenceDue
-          event={event as OrderEditDifferenceDueEvent}
-        />
-      )
+    case "refund-difference-due":
+      return <RefundDifferenceDue event={event as RefundDifferenceDueEvent} />
     case "edit-requested-difference-due":
       return (
         <EditRequestedDifferenceDue

--- a/src/domain/orders/details/index.tsx
+++ b/src/domain/orders/details/index.tsx
@@ -58,6 +58,7 @@ import {
 import OrderEditModal from "../edit/modal"
 import { FeatureFlagContext } from "../../../context/feature-flag"
 import useOrdersExpandParam from "./utils/use-admin-expand-paramter"
+import OrderEditProvider, { OrderEditContext } from "../edit/context"
 
 type OrderDetailFulfillment = {
   title: string
@@ -119,7 +120,6 @@ type OrderDetailProps = RouteComponentProps<{ id: string }>
 
 const OrderDetails = ({ id }: OrderDetailProps) => {
   const { isFeatureEnabled } = React.useContext(FeatureFlagContext)
-  const { orderRelations } = useOrdersExpandParam()
   const dialog = useImperativeDialog()
 
   const [addressModal, setAddressModal] = useState<null | {
@@ -132,7 +132,6 @@ const OrderDetails = ({ id }: OrderDetailProps) => {
   }>(null)
 
   const [showFulfillment, setShowFulfillment] = useState(false)
-  const [showOrderEdit, setShowOrderEdit] = useState(false)
   const [showRefund, setShowRefund] = useState(false)
   const [fullfilmentToShip, setFullfilmentToShip] = useState(null)
 
@@ -266,397 +265,403 @@ const OrderDetails = ({ id }: OrderDetailProps) => {
 
   return (
     <div>
-      <Breadcrumb
-        currentPage={"Order Details"}
-        previousBreadcrumb={"Orders"}
-        previousRoute="/a/orders"
-      />
-      {isLoading || !order ? (
-        <BodyCard className="w-full pt-2xlarge flex items-center justify-center">
-          <Spinner size={"large"} variant={"secondary"} />
-        </BodyCard>
-      ) : (
-        <>
-          <div className="flex space-x-4">
-            <div className="flex flex-col w-7/12 h-full">
-              <BodyCard
-                className={"w-full mb-4 min-h-[200px]"}
-                customHeader={
-                  <Tooltip side="top" content={"Copy ID"}>
-                    <button
-                      className="inter-xlarge-semibold text-grey-90 active:text-violet-90 cursor-pointer gap-x-2 flex items-center"
-                      onClick={handleCopy}
-                    >
-                      #{order.display_id} <ClipboardCopyIcon size={16} />
-                    </button>
-                  </Tooltip>
-                }
-                subtitle={moment(order.created_at).format(
-                  "d MMMM YYYY hh:mm a"
-                )}
-                status={<OrderStatusComponent status={order.status} />}
-                forceDropdown={true}
-                actionables={[
-                  {
-                    label: "Cancel Order",
-                    icon: <CancelIcon size={"20"} />,
-                    variant: "danger",
-                    onClick: () => handleDeleteOrder(),
-                  },
-                ]}
-              >
-                <div className="flex mt-6 space-x-6 divide-x">
-                  <div className="flex flex-col">
-                    <div className="inter-smaller-regular text-grey-50 mb-1">
-                      Email
+      <OrderEditProvider orderId={id}>
+        <Breadcrumb
+          currentPage={"Order Details"}
+          previousBreadcrumb={"Orders"}
+          previousRoute="/a/orders"
+        />
+        {isLoading || !order ? (
+          <BodyCard className="w-full pt-2xlarge flex items-center justify-center">
+            <Spinner size={"large"} variant={"secondary"} />
+          </BodyCard>
+        ) : (
+          <>
+            <div className="flex space-x-4">
+              <div className="flex flex-col w-7/12 h-full">
+                <BodyCard
+                  className={"w-full mb-4 min-h-[200px]"}
+                  customHeader={
+                    <Tooltip side="top" content={"Copy ID"}>
+                      <button
+                        className="inter-xlarge-semibold text-grey-90 active:text-violet-90 cursor-pointer gap-x-2 flex items-center"
+                        onClick={handleCopy}
+                      >
+                        #{order.display_id} <ClipboardCopyIcon size={16} />
+                      </button>
+                    </Tooltip>
+                  }
+                  subtitle={moment(order.created_at).format(
+                    "d MMMM YYYY hh:mm a"
+                  )}
+                  status={<OrderStatusComponent status={order.status} />}
+                  forceDropdown={true}
+                  actionables={[
+                    {
+                      label: "Cancel Order",
+                      icon: <CancelIcon size={"20"} />,
+                      variant: "danger",
+                      onClick: () => handleDeleteOrder(),
+                    },
+                  ]}
+                >
+                  <div className="flex mt-6 space-x-6 divide-x">
+                    <div className="flex flex-col">
+                      <div className="inter-smaller-regular text-grey-50 mb-1">
+                        Email
+                      </div>
+                      <button
+                        className="text-grey-90 active:text-violet-90 cursor-pointer gap-x-1 flex items-center"
+                        onClick={handleCopyEmail}
+                      >
+                        {order.email}
+                        <ClipboardCopyIcon size={12} />
+                      </button>
                     </div>
-                    <button
-                      className="text-grey-90 active:text-violet-90 cursor-pointer gap-x-1 flex items-center"
-                      onClick={handleCopyEmail}
-                    >
-                      {order.email}
-                      <ClipboardCopyIcon size={12} />
-                    </button>
+                    <div className="flex flex-col pl-6">
+                      <div className="inter-smaller-regular text-grey-50 mb-1">
+                        Phone
+                      </div>
+                      <div>{order.shipping_address?.phone || "N/A"}</div>
+                    </div>
+                    <div className="flex flex-col pl-6">
+                      <div className="inter-smaller-regular text-grey-50 mb-1">
+                        Payment
+                      </div>
+                      <div>
+                        {order.payments
+                          ?.map((p) => capitalize(p.provider_id))
+                          .join(", ")}
+                      </div>
+                    </div>
                   </div>
-                  <div className="flex flex-col pl-6">
-                    <div className="inter-smaller-regular text-grey-50 mb-1">
-                      Phone
-                    </div>
-                    <div>{order.shipping_address?.phone || "N/A"}</div>
-                  </div>
-                  <div className="flex flex-col pl-6">
-                    <div className="inter-smaller-regular text-grey-50 mb-1">
-                      Payment
-                    </div>
-                    <div>
-                      {order.payments
-                        ?.map((p) => capitalize(p.provider_id))
-                        .join(", ")}
-                    </div>
-                  </div>
-                </div>
-              </BodyCard>
-              <BodyCard
-                className={"w-full mb-4 min-h-0 h-auto"}
-                title="Summary"
-                actionables={
-                  isFeatureEnabled("order_editing")
-                    ? [
-                        {
-                          label: "Edit Order",
-                          onClick: () => setShowOrderEdit(true),
-                        },
-                      ]
-                    : undefined
-                }
-              >
-                <div className="mt-6">
-                  {order.items?.map((item, i) => (
-                    <OrderLine
-                      key={i}
-                      item={item}
-                      currencyCode={order.currency_code}
-                    />
-                  ))}
-                  <DisplayTotal
-                    currency={order.currency_code}
-                    totalAmount={order.subtotal}
-                    totalTitle={"Subtotal"}
-                  />
-                  {order?.discounts?.map((discount, index) => (
-                    <DisplayTotal
-                      key={index}
-                      currency={order.currency_code}
-                      totalAmount={-1 * order.discount_total}
-                      totalTitle={
-                        <div className="flex inter-small-regular text-grey-90 items-center">
-                          Discount:{" "}
-                          <Badge className="ml-3" variant="default">
-                            {discount.code}
-                          </Badge>
-                        </div>
+                </BodyCard>
+                <OrderEditContext.Consumer>
+                  {({ showModal }) => (
+                    <BodyCard
+                      className={"w-full mb-4 min-h-0 h-auto"}
+                      title="Summary"
+                      actionables={
+                        isFeatureEnabled("order_editing")
+                          ? [
+                              {
+                                label: "Edit Order",
+                                onClick: showModal,
+                              },
+                            ]
+                          : undefined
                       }
+                    >
+                      <div className="mt-6">
+                        {order.items?.map((item, i) => (
+                          <OrderLine
+                            key={i}
+                            item={item}
+                            currencyCode={order.currency_code}
+                          />
+                        ))}
+                        <DisplayTotal
+                          currency={order.currency_code}
+                          totalAmount={order.subtotal}
+                          totalTitle={"Subtotal"}
+                        />
+                        {order?.discounts?.map((discount, index) => (
+                          <DisplayTotal
+                            key={index}
+                            currency={order.currency_code}
+                            totalAmount={-1 * order.discount_total}
+                            totalTitle={
+                              <div className="flex inter-small-regular text-grey-90 items-center">
+                                Discount:{" "}
+                                <Badge className="ml-3" variant="default">
+                                  {discount.code}
+                                </Badge>
+                              </div>
+                            }
+                          />
+                        ))}
+                        {order?.gift_cards?.map((giftCard, index) => (
+                          <DisplayTotal
+                            key={index}
+                            currency={order.currency_code}
+                            totalAmount={-1 * order.gift_card_total}
+                            totalTitle={
+                              <div className="flex inter-small-regular text-grey-90 items-center">
+                                Gift card:{" "}
+                                <Badge className="ml-3" variant="default">
+                                  {giftCard.code}
+                                </Badge>
+                                <div className="ml-2">
+                                  <CopyToClipboard
+                                    value={giftCard.code}
+                                    showValue={false}
+                                    iconSize={16}
+                                  />
+                                </div>
+                              </div>
+                            }
+                          />
+                        ))}
+                        <DisplayTotal
+                          currency={order.currency_code}
+                          totalAmount={order.shipping_total}
+                          totalTitle={"Shipping"}
+                        />
+                        <DisplayTotal
+                          currency={order.currency_code}
+                          totalAmount={order.tax_total}
+                          totalTitle={`Tax`}
+                        />
+                        <DisplayTotal
+                          variant={"large"}
+                          currency={order.currency_code}
+                          totalAmount={order.total}
+                          totalTitle={hasMovements ? "Original Total" : "Total"}
+                        />
+                        <PaymentDetails
+                          manualRefund={manualRefund}
+                          swapAmount={swapAmount}
+                          swapRefund={swapRefund}
+                          returnRefund={returnRefund}
+                          paidTotal={order.paid_total}
+                          refundedTotal={order.refunded_total}
+                          currency={order.currency_code}
+                        />
+                      </div>
+                    </BodyCard>
+                  )}
+                </OrderEditContext.Consumer>
+
+                <BodyCard
+                  className={"w-full mb-4 min-h-0 h-auto"}
+                  title="Payment"
+                  status={
+                    <PaymentStatusComponent status={order.payment_status} />
+                  }
+                  customActionable={
+                    <PaymentActionables
+                      order={order}
+                      capturePayment={capturePayment}
+                      showRefundMenu={() => setShowRefund(true)}
                     />
-                  ))}
-                  {order?.gift_cards?.map((giftCard, index) => (
-                    <DisplayTotal
-                      key={index}
-                      currency={order.currency_code}
-                      totalAmount={-1 * order.gift_card_total}
-                      totalTitle={
-                        <div className="flex inter-small-regular text-grey-90 items-center">
-                          Gift card:{" "}
-                          <Badge className="ml-3" variant="default">
-                            {giftCard.code}
-                          </Badge>
-                          <div className="ml-2">
-                            <CopyToClipboard
-                              value={giftCard.code}
-                              showValue={false}
-                              iconSize={16}
+                  }
+                >
+                  <div className="mt-6">
+                    {order.payments.map((payment) => (
+                      <div className="flex flex-col" key={payment.id}>
+                        <DisplayTotal
+                          currency={order.currency_code}
+                          totalAmount={payment.amount}
+                          totalTitle={payment.id}
+                          subtitle={`${moment(payment.created_at).format(
+                            "DD MMM YYYY hh:mm"
+                          )}`}
+                        />
+                        {!!payment.amount_refunded && (
+                          <div className="flex justify-between mt-4">
+                            <div className="flex">
+                              <div className="text-grey-40 mr-2">
+                                <CornerDownRightIcon />
+                              </div>
+                              <div className="inter-small-regular text-grey-90">
+                                Refunded
+                              </div>
+                            </div>
+                            <div className="flex">
+                              <div className="inter-small-regular text-grey-90 mr-3">
+                                -
+                                {formatAmountWithSymbol({
+                                  amount: payment.amount_refunded,
+                                  currency: order.currency_code,
+                                })}
+                              </div>
+                              <div className="inter-small-regular text-grey-50">
+                                {order.currency_code.toUpperCase()}
+                              </div>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                    <div className="flex justify-between mt-4">
+                      <div className="inter-small-semibold text-grey-90">
+                        Total Paid
+                      </div>
+                      <div className="flex">
+                        <div className="inter-small-semibold text-grey-90 mr-3">
+                          {formatAmountWithSymbol({
+                            amount: order.paid_total - order.refunded_total,
+                            currency: order.currency_code,
+                          })}
+                        </div>
+                        <div className="inter-small-regular text-grey-50">
+                          {order.currency_code.toUpperCase()}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </BodyCard>
+                <BodyCard
+                  className={"w-full mb-4 min-h-0 h-auto"}
+                  title="Fulfillment"
+                  status={
+                    <FulfillmentStatusComponent
+                      status={order.fulfillment_status}
+                    />
+                  }
+                  customActionable={
+                    order.fulfillment_status !== "fulfilled" &&
+                    order.status !== "canceled" &&
+                    order.fulfillment_status !== "shipped" && (
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() => setShowFulfillment(true)}
+                      >
+                        Create Fulfillment
+                      </Button>
+                    )
+                  }
+                >
+                  <div className="mt-6">
+                    {order.shipping_methods.map((method) => (
+                      <div className="flex flex-col" key={method.id}>
+                        <span className="inter-small-regular text-grey-50">
+                          Shipping Method
+                        </span>
+                        <span className="inter-small-regular text-grey-90 mt-2">
+                          {method?.shipping_option?.name || ""}
+                        </span>
+                        <div className="flex flex-col min-h-[100px] mt-8 bg-grey-5 px-3 py-2 h-full">
+                          <span className="inter-base-semibold">
+                            Data{" "}
+                            <span className="text-grey-50 inter-base-regular">
+                              (1 item)
+                            </span>
+                          </span>
+                          <div className="flex flex-grow items-center mt-4">
+                            <ReactJson
+                              name={false}
+                              collapsed={true}
+                              src={method?.data}
                             />
                           </div>
                         </div>
-                      }
-                    />
-                  ))}
-                  <DisplayTotal
-                    currency={order.currency_code}
-                    totalAmount={order.shipping_total}
-                    totalTitle={"Shipping"}
-                  />
-                  <DisplayTotal
-                    currency={order.currency_code}
-                    totalAmount={order.tax_total}
-                    totalTitle={`Tax`}
-                  />
-                  <DisplayTotal
-                    variant={"large"}
-                    currency={order.currency_code}
-                    totalAmount={order.total}
-                    totalTitle={hasMovements ? "Original Total" : "Total"}
-                  />
-                  <PaymentDetails
-                    manualRefund={manualRefund}
-                    swapAmount={swapAmount}
-                    swapRefund={swapRefund}
-                    returnRefund={returnRefund}
-                    paidTotal={order.paid_total}
-                    refundedTotal={order.refunded_total}
-                    currency={order.currency_code}
-                  />
-                </div>
-              </BodyCard>
-              <BodyCard
-                className={"w-full mb-4 min-h-0 h-auto"}
-                title="Payment"
-                status={
-                  <PaymentStatusComponent status={order.payment_status} />
-                }
-                customActionable={
-                  <PaymentActionables
-                    order={order}
-                    capturePayment={capturePayment}
-                    showRefundMenu={() => setShowRefund(true)}
-                  />
-                }
-              >
-                <div className="mt-6">
-                  {order.payments.map((payment) => (
-                    <div className="flex flex-col" key={payment.id}>
-                      <DisplayTotal
-                        currency={order.currency_code}
-                        totalAmount={payment.amount}
-                        totalTitle={payment.id}
-                        subtitle={`${moment(payment.created_at).format(
-                          "DD MMM YYYY hh:mm"
-                        )}`}
-                      />
-                      {!!payment.amount_refunded && (
-                        <div className="flex justify-between mt-4">
-                          <div className="flex">
-                            <div className="text-grey-40 mr-2">
-                              <CornerDownRightIcon />
-                            </div>
-                            <div className="inter-small-regular text-grey-90">
-                              Refunded
-                            </div>
-                          </div>
-                          <div className="flex">
-                            <div className="inter-small-regular text-grey-90 mr-3">
-                              -
-                              {formatAmountWithSymbol({
-                                amount: payment.amount_refunded,
-                                currency: order.currency_code,
-                              })}
-                            </div>
-                            <div className="inter-small-regular text-grey-50">
-                              {order.currency_code.toUpperCase()}
-                            </div>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                  <div className="flex justify-between mt-4">
-                    <div className="inter-small-semibold text-grey-90">
-                      Total Paid
-                    </div>
-                    <div className="flex">
-                      <div className="inter-small-semibold text-grey-90 mr-3">
-                        {formatAmountWithSymbol({
-                          amount: order.paid_total - order.refunded_total,
-                          currency: order.currency_code,
-                        })}
                       </div>
-                      <div className="inter-small-regular text-grey-50">
-                        {order.currency_code.toUpperCase()}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </BodyCard>
-              <BodyCard
-                className={"w-full mb-4 min-h-0 h-auto"}
-                title="Fulfillment"
-                status={
-                  <FulfillmentStatusComponent
-                    status={order.fulfillment_status}
-                  />
-                }
-                customActionable={
-                  order.fulfillment_status !== "fulfilled" &&
-                  order.status !== "canceled" &&
-                  order.fulfillment_status !== "shipped" && (
-                    <Button
-                      variant="secondary"
-                      size="small"
-                      onClick={() => setShowFulfillment(true)}
-                    >
-                      Create Fulfillment
-                    </Button>
-                  )
-                }
-              >
-                <div className="mt-6">
-                  {order.shipping_methods.map((method) => (
-                    <div className="flex flex-col" key={method.id}>
-                      <span className="inter-small-regular text-grey-50">
-                        Shipping Method
-                      </span>
-                      <span className="inter-small-regular text-grey-90 mt-2">
-                        {method?.shipping_option?.name || ""}
-                      </span>
-                      <div className="flex flex-col min-h-[100px] mt-8 bg-grey-5 px-3 py-2 h-full">
-                        <span className="inter-base-semibold">
-                          Data{" "}
-                          <span className="text-grey-50 inter-base-regular">
-                            (1 item)
-                          </span>
-                        </span>
-                        <div className="flex flex-grow items-center mt-4">
-                          <ReactJson
-                            name={false}
-                            collapsed={true}
-                            src={method?.data}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                  <div className="mt-6 inter-small-regular ">
-                    {allFulfillments.map((fulfillmentObj, i) => (
-                      <FormattedFulfillment
-                        key={i}
-                        order={order}
-                        fulfillmentObj={fulfillmentObj}
-                        setFullfilmentToShip={setFullfilmentToShip}
-                      />
                     ))}
+                    <div className="mt-6 inter-small-regular ">
+                      {allFulfillments.map((fulfillmentObj, i) => (
+                        <FormattedFulfillment
+                          key={i}
+                          order={order}
+                          fulfillmentObj={fulfillmentObj}
+                          setFullfilmentToShip={setFullfilmentToShip}
+                        />
+                      ))}
+                    </div>
                   </div>
-                </div>
-              </BodyCard>
-              <BodyCard
-                className={"w-full mb-4 min-h-0 h-auto"}
-                title="Customer"
-                actionables={customerActionables}
-              >
-                <div className="mt-6">
-                  <div className="flex w-full space-x-4 items-center">
-                    <div className="flex w-[40px] h-[40px] ">
-                      <Avatar
-                        user={order.customer}
-                        font="inter-large-semibold"
-                        color="bg-fuschia-40"
+                </BodyCard>
+                <BodyCard
+                  className={"w-full mb-4 min-h-0 h-auto"}
+                  title="Customer"
+                  actionables={customerActionables}
+                >
+                  <div className="mt-6">
+                    <div className="flex w-full space-x-4 items-center">
+                      <div className="flex w-[40px] h-[40px] ">
+                        <Avatar
+                          user={order.customer}
+                          font="inter-large-semibold"
+                          color="bg-fuschia-40"
+                        />
+                      </div>
+                      <div>
+                        <h1 className="inter-large-semibold text-grey-90">
+                          {extractCustomerName(order)}
+                        </h1>
+                        {order.shipping_address && (
+                          <span className="inter-small-regular text-grey-50">
+                            {order.shipping_address.city},{" "}
+                            {
+                              isoAlpha2Countries[
+                                order.shipping_address.country_code?.toUpperCase()
+                              ]
+                            }
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex mt-6 space-x-6 divide-x">
+                      <div className="flex flex-col">
+                        <div className="inter-small-regular text-grey-50 mb-1">
+                          Contact
+                        </div>
+                        <div className="flex flex-col inter-small-regular">
+                          <span>{order.email}</span>
+                          <span>{order.shipping_address?.phone || ""}</span>
+                        </div>
+                      </div>
+                      <FormattedAddress
+                        title={"Shipping"}
+                        addr={order.shipping_address}
+                      />
+                      <FormattedAddress
+                        title={"Billing"}
+                        addr={order.billing_address}
                       />
                     </div>
-                    <div>
-                      <h1 className="inter-large-semibold text-grey-90">
-                        {extractCustomerName(order)}
-                      </h1>
-                      {order.shipping_address && (
-                        <span className="inter-small-regular text-grey-50">
-                          {order.shipping_address.city},{" "}
-                          {
-                            isoAlpha2Countries[
-                              order.shipping_address.country_code?.toUpperCase()
-                            ]
-                          }
-                        </span>
-                      )}
-                    </div>
                   </div>
-                  <div className="flex mt-6 space-x-6 divide-x">
-                    <div className="flex flex-col">
-                      <div className="inter-small-regular text-grey-50 mb-1">
-                        Contact
-                      </div>
-                      <div className="flex flex-col inter-small-regular">
-                        <span>{order.email}</span>
-                        <span>{order.shipping_address?.phone || ""}</span>
-                      </div>
-                    </div>
-                    <FormattedAddress
-                      title={"Shipping"}
-                      addr={order.shipping_address}
-                    />
-                    <FormattedAddress
-                      title={"Billing"}
-                      addr={order.billing_address}
-                    />
-                  </div>
+                </BodyCard>
+                <div className="mt-large">
+                  <RawJSON data={order} title="Raw order" />
                 </div>
-              </BodyCard>
-              <div className="mt-large">
-                <RawJSON data={order} title="Raw order" />
               </div>
+              <Timeline orderId={order.id} />
             </div>
-            <Timeline orderId={order.id} />
-          </div>
-          {addressModal && (
-            <AddressModal
-              handleClose={() => setAddressModal(null)}
-              submit={updateOrder}
-              address={addressModal.address}
-              type={addressModal.type}
-              allowedCountries={region?.countries}
-            />
-          )}
-          {emailModal && (
-            <EmailModal
-              handleClose={() => setEmailModal(null)}
-              email={emailModal.email}
-              orderId={order.id}
-            />
-          )}
-          {showFulfillment && (
-            <CreateFulfillmentModal
-              orderToFulfill={order as any}
-              handleCancel={() => setShowFulfillment(false)}
-              orderId={order.id}
-            />
-          )}
-          {showRefund && (
-            <CreateRefundModal
-              order={order}
-              onDismiss={() => setShowRefund(false)}
-            />
-          )}
-          {fullfilmentToShip && (
-            <MarkShippedModal
-              handleCancel={() => setFullfilmentToShip(null)}
-              fulfillment={fullfilmentToShip}
-              orderId={order.id}
-            />
-          )}
-          {showOrderEdit && (
-            <OrderEditModal
-              orderId={order.id}
-              close={() => setShowOrderEdit(false)}
-            />
-          )}
-        </>
-      )}
+            {addressModal && (
+              <AddressModal
+                handleClose={() => setAddressModal(null)}
+                submit={updateOrder}
+                address={addressModal.address}
+                type={addressModal.type}
+                allowedCountries={region?.countries}
+              />
+            )}
+            {emailModal && (
+              <EmailModal
+                handleClose={() => setEmailModal(null)}
+                email={emailModal.email}
+                orderId={order.id}
+              />
+            )}
+            {showFulfillment && (
+              <CreateFulfillmentModal
+                orderToFulfill={order as any}
+                handleCancel={() => setShowFulfillment(false)}
+                orderId={order.id}
+              />
+            )}
+            {showRefund && (
+              <CreateRefundModal
+                order={order}
+                onDismiss={() => setShowRefund(false)}
+              />
+            )}
+            {fullfilmentToShip && (
+              <MarkShippedModal
+                handleCancel={() => setFullfilmentToShip(null)}
+                fulfillment={fullfilmentToShip}
+                orderId={order.id}
+              />
+            )}
+            <OrderEditContext.Consumer>
+              {({ isModalVisible }) =>
+                isModalVisible && <OrderEditModal order={order} />
+              }
+            </OrderEditContext.Consumer>
+          </>
+        )}
+      </OrderEditProvider>
     </div>
   )
 }

--- a/src/domain/orders/details/order-line/edit.tsx
+++ b/src/domain/orders/details/order-line/edit.tsx
@@ -20,6 +20,7 @@ import useNotification from "../../../../hooks/use-notification"
 import { LayeredModalContext } from "../../../../components/molecules/modal/layered-modal"
 import { AddProductVariant } from "../../edit/modal"
 import Tooltip from "../../../../components/atoms/tooltip"
+import CopyToClipboard from "../../../../components/atoms/copy-to-clipboard"
 
 type OrderEditLineProps = {
   item: LineItem
@@ -164,10 +165,10 @@ const OrderEditLine = ({
               <ImagePlaceholder />
             )}
           </div>
-          <div className="flex flex-col justify-center max-w-[185px]">
+          <div className="flex flex-col justify-center">
             <div>
               <span
-                className={clsx("inter-small-regular text-grey-900 truncate", {
+                className={clsx("inter-small-regular text-grey-900", {
                   "text-gray-400": isLocked,
                 })}
               >
@@ -187,20 +188,23 @@ const OrderEditLine = ({
                 </div>
               )}
 
-              {item?.variant && (
-                <span
-                  className={clsx(
-                    "inter-small-regular text-gray-500 truncate",
-                    {
-                      "text-gray-400": isLocked,
-                    }
-                  )}
-                >
-                  {`${item.variant.title}${
-                    item.variant.sku ? ` (${item.variant.sku})` : ""
-                  }`}
-                </span>
-              )}
+              <div className="min-h-[20px]">
+                {item?.variant && (
+                  <span
+                    className={clsx(
+                      "inter-small-regular text-gray-500 flex gap-3",
+                      {
+                        "text-gray-400": isLocked,
+                      }
+                    )}
+                  >
+                    {item.variant.title}
+                    {item.variant.sku && (
+                      <CopyToClipboard value={item.variant.sku} iconSize={14} />
+                    )}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/domain/orders/details/order-line/edit.tsx
+++ b/src/domain/orders/details/order-line/edit.tsx
@@ -30,6 +30,8 @@ type OrderEditLineProps = {
   change?: OrderItemChange
 }
 
+let isLoading = false
+
 const OrderEditLine = ({
   item,
   currencyCode,
@@ -64,7 +66,16 @@ const OrderEditLine = ({
   )
 
   const onQuantityUpdate = async (newQuantity: number) => {
-    await updateItem({ quantity: newQuantity })
+    if (isLoading) {
+      return
+    }
+
+    isLoading = true
+    try {
+      await updateItem({ quantity: newQuantity })
+    } finally {
+      isLoading = false
+    }
   }
 
   const onDuplicate = async () => {
@@ -215,7 +226,9 @@ const OrderEditLine = ({
             })}
           >
             <MinusIcon
-              className="cursor-pointer"
+              className={clsx("cursor-pointer text-gray-400", {
+                "pointer-events-none": isLoading,
+              })}
               onClick={() =>
                 item.quantity > 1 &&
                 !isLocked &&
@@ -230,7 +243,9 @@ const OrderEditLine = ({
               {item.quantity}
             </span>
             <PlusIcon
-              className="cursor-pointer text-gray-400"
+              className={clsx("cursor-pointer text-gray-400", {
+                "pointer-events-none": isLoading,
+              })}
               onClick={() => onQuantityUpdate(item.quantity + 1)}
             />
           </div>

--- a/src/domain/orders/details/order-line/edit.tsx
+++ b/src/domain/orders/details/order-line/edit.tsx
@@ -242,9 +242,12 @@ const OrderEditLine = ({
             )}
           >
             <div
-              className={clsx("inter-small-regular text-gray-900", {
-                "!text-gray-400 pointer-events-none": isLocked,
-              })}
+              className={clsx(
+                "inter-small-regular text-gray-900 min-w-[60px] text-right",
+                {
+                  "!text-gray-400 pointer-events-none": isLocked,
+                }
+              )}
             >
               {formatAmountWithSymbol({
                 amount: item.unit_price * item.quantity,

--- a/src/domain/orders/details/order-line/edit.tsx
+++ b/src/domain/orders/details/order-line/edit.tsx
@@ -154,7 +154,7 @@ const OrderEditLine = ({
     <Tooltip
       side="top"
       open={isLocked ? undefined : false}
-      content="This item is locked because it is part of an active order edit request"
+      content="This line item is part of a fulfillment and cannot be edited. Cancel the fulfillment to edit the line item."
     >
       <div className="flex justify-between mb-1 h-[64px] py-2 mx-[-5px] px-[5px] hover:bg-grey-5 rounded-rounded">
         <div className="flex space-x-4 justify-center flex-grow-1">

--- a/src/domain/orders/details/refund/index.tsx
+++ b/src/domain/orders/details/refund/index.tsx
@@ -1,6 +1,8 @@
+import { Order } from "@medusajs/medusa"
 import { useAdminRefundPayment } from "medusa-react"
 import React, { useMemo, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
+
 import Button from "../../../../components/fundamentals/button"
 import AlertIcon from "../../../../components/fundamentals/icons/alert-icon"
 import CheckIcon from "../../../../components/fundamentals/icons/check-icon"
@@ -21,8 +23,30 @@ type RefundMenuFormData = {
   note?: string
 }
 
-const RefundMenu = ({ order, onDismiss }) => {
-  const { register, handleSubmit, control } = useForm<RefundMenuFormData>()
+const reasonOptions = [
+  { label: "Discount", value: "discount" },
+  { label: "Other", value: "other" },
+]
+
+type RefundMenuProps = {
+  order: Order
+  onDismiss: () => void
+  initialAmount?: number
+  initialReason: "other" | "discount"
+}
+
+const RefundMenu = ({
+  order,
+  onDismiss,
+  initialAmount,
+  initialReason,
+}: RefundMenuProps) => {
+  const { register, handleSubmit, control } = useForm<RefundMenuFormData>({
+    defaultValues: {
+      amount: initialAmount,
+      reason: reasonOptions[initialReason === "other" ? 1 : 0],
+    },
+  })
 
   const [noNotification, setNoNotification] = useState(order.no_notification)
 
@@ -32,11 +56,6 @@ const RefundMenu = ({ order, onDismiss }) => {
   const refundable = useMemo(() => {
     return order.paid_total - order.refunded_total
   }, [order])
-
-  const reasonOptions = [
-    { label: "Discount", value: "discount" },
-    { label: "Other", value: "other" },
-  ]
 
   const handleValidateRefundAmount = (value) => {
     return value <= refundable

--- a/src/domain/orders/edit/context.tsx
+++ b/src/domain/orders/edit/context.tsx
@@ -1,9 +1,4 @@
-import React, {
-  createContext,
-  PropsWithChildren,
-  useEffect,
-  useState,
-} from "react"
+import React, { createContext, PropsWithChildren } from "react"
 import { useAdminOrderEdits } from "medusa-react"
 import { OrderEdit } from "@medusajs/medusa"
 
@@ -21,6 +16,8 @@ export type IOrderEditContext = {
   orderEdits?: OrderEdit[]
 }
 
+let activeId = undefined
+
 // @ts-ignore
 export const OrderEditContext = createContext<IOrderEditContext>({})
 
@@ -29,28 +26,20 @@ type OrderEditProviderProps = PropsWithChildren<{ orderId: string }>
 function OrderEditProvider(props: OrderEditProviderProps) {
   const { orderId } = props
   const [isModalVisible, showModal, hideModal] = useToggleState(false)
-  const [activeOrderEditId, setActiveOrderEdit] = useState<string>()
 
-  var { order_edits, count } = useAdminOrderEdits({
+  // TODO: sort by created_at
+  const { order_edits, count } = useAdminOrderEdits({
     order_id: orderId,
-    limit: count,
+    //limit: count, // TODO
   })
-
-  useEffect(() => {
-    const activeOrderEdit = order_edits?.find((oe) => oe.status === "created")
-
-    if (activeOrderEdit) {
-      setActiveOrderEdit(activeOrderEdit.id)
-    }
-  }, [order_edits])
 
   const value = {
     isModalVisible,
     showModal,
     hideModal,
     orderEdits: order_edits,
-    activeOrderEditId,
-    setActiveOrderEdit,
+    activeOrderEditId: activeId,
+    setActiveOrderEdit: (id: string | undefined) => (activeId = id),
   }
 
   return <OrderEditContext.Provider value={value} children={props.children} />

--- a/src/domain/orders/edit/context.tsx
+++ b/src/domain/orders/edit/context.tsx
@@ -1,0 +1,59 @@
+import React, {
+  createContext,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from "react"
+import { useAdminOrderEdits } from "medusa-react"
+import { OrderEdit } from "@medusajs/medusa"
+
+import useToggleState from "../../../hooks/use-toggle-state"
+
+export type IOrderEditContext = {
+  showModal: () => void
+  hideModal: () => void
+
+  isModalVisible: boolean
+
+  activeOrderEditId?: string
+  setActiveOrderEdit: (orderEditId?: string) => string
+
+  orderEdits?: OrderEdit[]
+}
+
+// @ts-ignore
+export const OrderEditContext = createContext<IOrderEditContext>({})
+
+type OrderEditProviderProps = PropsWithChildren<{ orderId: string }>
+
+function OrderEditProvider(props: OrderEditProviderProps) {
+  const { orderId } = props
+  const [isModalVisible, showModal, hideModal] = useToggleState(false)
+  const [activeOrderEditId, setActiveOrderEdit] = useState<string>()
+
+  var { order_edits, count } = useAdminOrderEdits({
+    order_id: orderId,
+    limit: count,
+  })
+
+  useEffect(() => {
+    const activeOrderEdit = order_edits?.find((oe) => oe.status === "created")
+
+    if (activeOrderEdit) {
+      setActiveOrderEdit(activeOrderEdit.id)
+    }
+  }, [order_edits])
+
+  const value = {
+    isModalVisible,
+    showModal,
+    hideModal,
+    orderEdits: order_edits,
+    activeOrderEditId,
+    setActiveOrderEdit,
+  }
+
+  return <OrderEditContext.Provider value={value} children={props.children} />
+}
+
+export default OrderEditProvider

--- a/src/domain/orders/edit/modal.tsx
+++ b/src/domain/orders/edit/modal.tsx
@@ -1,5 +1,5 @@
-import { OrderEdit, ProductVariant } from "@medusajs/medusa"
-import clsx from "clsx"
+import React, { useContext, useEffect, useState } from "react"
+import { Order, OrderEdit, ProductVariant } from "@medusajs/medusa"
 import {
   useAdminCreateOrderEdit,
   useAdminDeleteOrderEdit,
@@ -9,19 +9,20 @@ import {
   useAdminRequestOrderEditConfirmation,
   useAdminUpdateOrderEdit,
 } from "medusa-react"
-import React, { useContext, useEffect, useState } from "react"
+import clsx from "clsx"
 
-import Button from "../../../components/fundamentals/button"
-import SearchIcon from "../../../components/fundamentals/icons/search-icon"
-import InputField from "../../../components/molecules/input"
-import Modal from "../../../components/molecules/modal"
 import LayeredModal, {
   LayeredModalContext,
 } from "../../../components/molecules/modal/layered-modal"
-import useNotification from "../../../hooks/use-notification"
-import { formatAmountWithSymbol } from "../../../utils/prices"
+import Modal from "../../../components/molecules/modal"
+import Button from "../../../components/fundamentals/button"
 import OrderEditLine from "../details/order-line/edit"
 import VariantsTable from "./variants-table"
+import SearchIcon from "../../../components/fundamentals/icons/search-icon"
+import { formatAmountWithSymbol } from "../../../utils/prices"
+import InputField from "../../../components/molecules/input"
+import useNotification from "../../../hooks/use-notification"
+import { OrderEditContext } from "./context"
 
 type TotalsSectionProps = {
   currentSubtotal: number
@@ -360,64 +361,61 @@ function OrderEditModal(props: OrderEditModalProps) {
 }
 
 type OrderEditModalContainerProps = {
-  orderId: string
-  close: () => void
+  order: Order
 }
 
 function OrderEditModalContainer(props: OrderEditModalContainerProps) {
+  const { order } = props
   const notification = useNotification()
 
-  // TODO: replace with the list endpoint
-  const { order } = useAdminOrder(props.orderId, { expand: "edits" })
-
-  const [activeOrderEditId, setActiveOrderEditId] = useState<
-    string | undefined
-  >()
+  const {
+    hideModal,
+    orderEdits,
+    activeOrderEditId,
+    setActiveOrderEdit,
+  } = useContext(OrderEditContext)
 
   const { mutate: createOrderEdit } = useAdminCreateOrderEdit()
 
-  const { order_edit: orderEdit } = useAdminOrderEdit(
-    activeOrderEditId as string,
-    {
-      enabled: typeof activeOrderEditId === "string",
-    }
-  )
+  const orderEdit = orderEdits?.find((oe) => oe.id === activeOrderEditId)
 
-  // find an existing edit or create one if active order edit doesn't exist on the order
   useEffect(() => {
-    if (!order || activeOrderEditId) {
+    if (activeOrderEditId) {
       return
     }
 
-    const edit = order.edits.find((oe) => oe.status === "created")
-
-    if (!edit) {
+    if (typeof orderEdits !== "undefined") {
       createOrderEdit(
         { order_id: order.id },
         {
-          onSuccess: ({ order_edit }) => setActiveOrderEditId(order_edit.id),
+          onSuccess: ({ order_edit }) => {
+            setActiveOrderEdit(order_edit.id)
+          },
           onError: () => {
             notification(
               "Error",
               "There is already active order edit on this order",
               "error"
             )
-            props.close()
+            hideModal()
           },
         }
       )
-    } else {
-      setActiveOrderEditId(edit.id)
     }
-  }, [order, activeOrderEditId])
+  }, [activeOrderEditId, orderEdits])
 
-  if (!orderEdit || !order) {
+  const onClose = () => {
+    setActiveOrderEdit(undefined)
+    hideModal()
+  }
+
+  if (!orderEdit) {
     return null
   }
 
   return (
     <OrderEditModal
-      close={props.close}
+      close={onClose}
       orderEdit={orderEdit}
       currentSubtotal={order.subtotal}
       regionId={order.region_id}

--- a/src/domain/orders/edit/modal.tsx
+++ b/src/domain/orders/edit/modal.tsx
@@ -3,8 +3,6 @@ import { Order, OrderEdit, ProductVariant } from "@medusajs/medusa"
 import {
   useAdminCreateOrderEdit,
   useAdminDeleteOrderEdit,
-  useAdminOrder,
-  useAdminOrderEdit,
   useAdminOrderEditAddLineItem,
   useAdminRequestOrderEditConfirmation,
   useAdminUpdateOrderEdit,
@@ -118,7 +116,7 @@ export function AddProductVariant(props: AddProductVariantProps) {
             regionId={props.regionId}
             customerId={props.customerId}
             currencyCode={props.currencyCode}
-            isReplace={props.isReplace}
+            isReplace={!!props.isReplace}
             setSelectedVariants={setSelectedVariants}
           />
         </div>

--- a/src/domain/orders/edit/modal.tsx
+++ b/src/domain/orders/edit/modal.tsx
@@ -384,24 +384,22 @@ function OrderEditModalContainer(props: OrderEditModalContainerProps) {
       return
     }
 
-    if (typeof orderEdits !== "undefined") {
-      createOrderEdit(
-        { order_id: order.id },
-        {
-          onSuccess: ({ order_edit }) => {
-            setActiveOrderEdit(order_edit.id)
-          },
-          onError: () => {
-            notification(
-              "Error",
-              "There is already active order edit on this order",
-              "error"
-            )
-            hideModal()
-          },
-        }
-      )
-    }
+    createOrderEdit(
+      { order_id: order.id },
+      {
+        onSuccess: ({ order_edit }) => {
+          setActiveOrderEdit(order_edit.id)
+        },
+        onError: () => {
+          notification(
+            "Error",
+            "There is already active order edit on this order",
+            "error"
+          )
+          hideModal()
+        },
+      }
+    )
   }, [activeOrderEditId, orderEdits])
 
   const onClose = () => {

--- a/src/domain/orders/edit/variants-table.tsx
+++ b/src/domain/orders/edit/variants-table.tsx
@@ -255,6 +255,7 @@ const VariantsTable: React.FC<Props> = (props) => {
         immediateSearchFocus
         enableSearch
         searchPlaceholder="Search Product Variants..."
+        searchValue={query}
         handleSearch={handleSearch}
         {...table.getTableProps()}
       >

--- a/src/domain/orders/edit/variants-table.tsx
+++ b/src/domain/orders/edit/variants-table.tsx
@@ -121,7 +121,7 @@ const VariantsTable: React.FC<Props> = (props) => {
         ),
         accessor: "amount",
         Cell: ({ row: { original } }) => {
-          if (!original.original_price) {
+          if (!original.original_price_incl_tax) {
             return null
           }
 
@@ -133,14 +133,14 @@ const VariantsTable: React.FC<Props> = (props) => {
                 {showOriginal && (
                   <span className="text-gray-400 line-through">
                     {formatAmountWithSymbol({
-                      amount: original.original_price,
+                      amount: original.original_price_incl_tax,
                       currency: currencyCode,
                     })}
                   </span>
                 )}
                 <span>
                   {formatAmountWithSymbol({
-                    amount: original.calculated_price,
+                    amount: original.calculated_price_incl_tax,
                     currency: currencyCode,
                   })}
                 </span>

--- a/src/domain/orders/edit/variants-table.tsx
+++ b/src/domain/orders/edit/variants-table.tsx
@@ -199,7 +199,6 @@ const VariantsTable: React.FC<Props> = (props) => {
               <div className={clsx({ "mr-2": isReplace })}>
                 <IndeterminateCheckbox
                   {...selectProps}
-                  disabled={row.original.inventory_quantity === 0}
                   type={isReplace ? "radio" : "checkbox"}
                   onChange={
                     isReplace
@@ -224,10 +223,7 @@ const VariantsTable: React.FC<Props> = (props) => {
       return
     }
 
-    const selected = variants.filter(
-      (v) => table.state.selectedRowIds[v.id] && v.inventory_quantity > 0
-    )
-
+    const selected = variants.filter((v) => table.state.selectedRowIds[v.id])
     setSelectedVariants(selected)
   }, [table.state.selectedRowIds, variants])
 
@@ -277,20 +273,9 @@ const VariantsTable: React.FC<Props> = (props) => {
             <Spinner size="large" />
           ) : (
             table.rows.map((row) => {
-              const isDisabled = row.original.inventory_quantity === 0
-
               table.prepareRow(row)
               return (
-                <Table.Row
-                  {...row.getRowProps()}
-                  className={isDisabled && "opacity-50 pointer-events-none"}
-                >
-                  {/*TODO: TOOLTIP CSS doesn't work with table layout*/}
-                  {/*<Tooltip*/}
-                  {/*  side="top"*/}
-                  {/*  open={isDisabled ? undefined : false}*/}
-                  {/*  content="This variant is out of stock, and does not allow backorders"*/}
-                  {/*>*/}
+                <Table.Row {...row.getRowProps()}>
                   {row.cells.map((cell) => {
                     return (
                       <Table.Cell {...cell.getCellProps()}>
@@ -298,7 +283,6 @@ const VariantsTable: React.FC<Props> = (props) => {
                       </Table.Cell>
                     )
                   })}
-                  {/*</Tooltip>*/}
                 </Table.Row>
               )
             })

--- a/src/hooks/use-build-timeline.tsx
+++ b/src/hooks/use-build-timeline.tsx
@@ -46,9 +46,8 @@ export interface OrderEditDifferenceDueEvent extends OrderEditEvent {
   currency_code: string
 }
 
-export interface OrderEditRequestedEvent extends TimelineEvent {
+export interface OrderEditRequestedEvent extends OrderEditEvent {
   email: string
-  edit: OrderEdit
 }
 
 interface CancelableEvent {

--- a/src/hooks/use-build-timeline.tsx
+++ b/src/hooks/use-build-timeline.tsx
@@ -504,8 +504,6 @@ export const useBuildTimeline = (orderId: string) => {
       }
     }
 
-    console.log(notifications)
-
     events.sort((a, b) => {
       if (a.time > b.time) {
         return -1

--- a/src/hooks/use-build-timeline.tsx
+++ b/src/hooks/use-build-timeline.tsx
@@ -48,6 +48,7 @@ export interface OrderEditDifferenceDueEvent extends OrderEditEvent {
 
 export interface OrderEditRequestedEvent extends TimelineEvent {
   email: string
+  edit: OrderEdit
 }
 
 interface CancelableEvent {
@@ -204,6 +205,7 @@ export const useBuildTimelime = (orderId: string) => {
             orderId: order.id,
             type: "edit-requested",
             email: order.email,
+            edit: edit,
           } as OrderEditRequestedEvent)
 
           events.push({

--- a/src/hooks/use-build-timeline.tsx
+++ b/src/hooks/use-build-timeline.tsx
@@ -119,7 +119,7 @@ export interface ExchangeEvent extends TimelineEvent, CancelableEvent {
   fulfillmentStatus: string
   returnStatus: string
   returnId: string
-  returnItems: ReturnItem[]
+  returnItems: (ReturnItem | undefined)[]
   newItems: OrderItem[]
   exchangeCartId?: string
   raw: Swap

--- a/src/hooks/use-build-timeline.tsx
+++ b/src/hooks/use-build-timeline.tsx
@@ -3,10 +3,10 @@ import {
   useAdminNotes,
   useAdminNotifications,
   useAdminOrder,
+  useAdminOrderEdits,
 } from "medusa-react"
 import { useContext, useMemo } from "react"
 import { FeatureFlagContext } from "../context/feature-flag"
-import useOrdersExpandParam from "../domain/orders/details/utils/use-admin-expand-paramter"
 
 export interface TimelineEvent {
   id: string
@@ -143,16 +143,14 @@ export interface NotificationEvent extends TimelineEvent {
 }
 
 export const useBuildTimelime = (orderId: string) => {
-  const { orderRelations } = useOrdersExpandParam()
-
   const {
     order,
     isLoading: orderLoading,
     isError: orderError,
     refetch,
-  } = useAdminOrder(orderId, {
-    expand: orderRelations,
-  })
+  } = useAdminOrder(orderId, {})
+
+  const { order_edits: edits } = useAdminOrderEdits({ order_id: orderId })
 
   const {
     notes,
@@ -190,7 +188,7 @@ export const useBuildTimelime = (orderId: string) => {
     const events: TimelineEvent[] = []
 
     if (isFeatureEnabled("order_editing")) {
-      for (const edit of order.edits || []) {
+      for (const edit of edits || []) {
         events.push({
           id: edit.id,
           time: edit.created_at,
@@ -515,6 +513,7 @@ export const useBuildTimelime = (orderId: string) => {
     return events
   }, [
     order,
+    edits,
     orderLoading,
     orderError,
     notes,


### PR DESCRIPTION
**What**
- fix bugs, align implementations of the modal and the timeline, fetch optimisations

**TODO**
- [x] use the list endpoint instead of `edits`relation (FIXES CORE-697)
- [x] hide timeline event while editing and handle stale edits (FIXES CORE-688)
- [x] refund OE doesn't show refund time line event for refunding (FIXES CORE-692)
- [x] OE with removed line items shows incorrectly (FIXES CORE-690)
- [x] add spacing in order edit time line event (FIXES CORE-708)
- [x] "Customer payment required" should not be shown if difference due is 0 (FIXES CORE-707)
- [x] copy SKU in edit modal (FIXES CORE-709)
- [x] Timeline event with "by" field should show email when no name is available (FIXES CORE-691)
- [x] show prices with taxes in modal
- [x] allow operators to select variants despite being out of stock
- [x] confirmation-request sent should show based on Notifications (FIXES CORE-718)
- [x] "Spamming" the quantity ticker on order editing results in error (FIXES CORE-717)