### PR TITLE
fix: option to select price_type (#597)

### DIFF
--- a/src/domain/settings/regions/components/shipping-option-card/edit-modal.tsx
+++ b/src/domain/settings/regions/components/shipping-option-card/edit-modal.tsx
@@ -111,6 +111,11 @@ const getDefaultValues = (option: ShippingOption): ShippingOptionFormType => {
   return {
     store_option: option.admin_only ? false : true,
     name: option.name,
+    price_type: {
+      label:
+        option.price_type === "flat_rate" ? "Flat rate" : "Calculated Price",
+      value: option.price_type,
+    },
     fulfillment_provider: null,
     shipping_profile: null,
     requirements: {

--- a/src/domain/settings/regions/components/shipping-option-form/index.tsx
+++ b/src/domain/settings/regions/components/shipping-option-form/index.tsx
@@ -6,7 +6,7 @@ import Switch from "../../../../../components/atoms/switch"
 import InputHeader from "../../../../../components/fundamentals/input-header"
 import InputField from "../../../../../components/molecules/input"
 import { NextSelect } from "../../../../../components/molecules/select/next-select"
-import { Option } from "../../../../../types/shared"
+import { Option, ShippingOptionPriceType } from "../../../../../types/shared"
 import FormValidator from "../../../../../utils/form-validator"
 import PriceFormInput from "../../../../products/components/prices-form/price-form-input"
 import { useShippingOptionFormData } from "./use-shipping-option-form-data"
@@ -19,6 +19,7 @@ type Requirement = {
 export type ShippingOptionFormType = {
   store_option: boolean
   name: string | null
+  price_type: ShippingOptionPriceType | null
   amount: number | null
   shipping_profile: Option | null
   fulfillment_provider: Option | null
@@ -37,6 +38,7 @@ type Props = {
 const ShippingOptionForm = ({ form, region, isEdit = false }: Props) => {
   const {
     register,
+    watch,
     control,
     formState: { errors },
   } = form
@@ -79,34 +81,66 @@ const ShippingOptionForm = ({ form, region, isEdit = false }: Props) => {
             })}
             errors={errors}
           />
-          <Controller
-            control={control}
-            name="amount"
-            rules={{
-              min: FormValidator.nonNegativeNumberRule("Price"),
-              max: FormValidator.maxInteger("Price", region.currency_code),
-            }}
-            render={({ field: { value, onChange } }) => {
-              return (
-                <div>
-                  <InputHeader
-                    label="Price"
-                    className="mb-xsmall"
-                    tooltip={
-                      <IncludesTaxTooltip includesTax={region.includes_tax} />
-                    }
-                  />
-                  <PriceFormInput
-                    amount={value || undefined}
-                    onChange={onChange}
-                    name="amount"
-                    currencyCode={region.currency_code}
+          <div className="flex items-center gap-large">
+            <Controller
+              control={control}
+              name="price_type"
+              render={({ field }) => {
+                return (
+                  <NextSelect
+                    label="Price Type"
+                    required
+                    options={[
+                      {
+                        label: "Flat Rate",
+                        value: "flat_rate",
+                      },
+                      {
+                        label: "Calculated",
+                        value: "calculated",
+                      },
+                    ]}
+                    placeholder="Choose a price type"
+                    {...field}
                     errors={errors}
                   />
-                </div>
-              )
-            }}
-          />
+                )
+              }}
+            />
+            {watch("price_type")?.value === "flat_rate" && (
+              <Controller
+                control={control}
+                name="amount"
+                rules={{
+                  min: FormValidator.nonNegativeNumberRule("Price"),
+                  max: FormValidator.maxInteger("Price", region.currency_code),
+                }}
+                render={({ field: { value, onChange } }) => {
+                  return (
+                    <div>
+                      <InputHeader
+                        label="Price"
+                        className="mb-2xsmall"
+                        tooltip={
+                          <IncludesTaxTooltip
+                            includesTax={region.includes_tax}
+                          />
+                        }
+                      />
+                      <PriceFormInput
+                        amount={value || undefined}
+                        onChange={onChange}
+                        name="amount"
+                        currencyCode={region.currency_code}
+                        errors={errors}
+                      />
+                    </div>
+                  )
+                }}
+              />
+            )}
+          </div>
+
           {!isEdit && (
             <>
               <Controller

--- a/src/domain/settings/regions/edit/shipping-options/create-shipping-option-modal.tsx
+++ b/src/domain/settings/regions/edit/shipping-options/create-shipping-option-modal.tsx
@@ -47,7 +47,7 @@ const CreateShippingOptionModal = ({ open, onClose, region }: Props) => {
         profile_id: data.shipping_profile?.value,
         name: data.name!,
         data: fData,
-        price_type: "flat_rate",
+        price_type: data.price_type!.value,
         provider_id,
         admin_only: !data.store_option,
         amount: data.amount!,

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -32,6 +32,11 @@ export type Role = {
   label: string
 }
 
+export type ShippingOptionPriceType = {
+  value: "flat_rate" | "calculated"
+  label: string
+}
+
 export type FormImage = {
   url: string
   name?: string


### PR DESCRIPTION
Here are the changes that were made to the layout during the fix:
- price type dropdown was added

### When we Select Flat Rate then the Price Input field is displayed.
![tmp1](https://user-images.githubusercontent.com/35496058/197651421-54f9b77e-44de-4739-824d-a2b6881e6771.PNG)
### Otherwise, the dropdown takes up the whole space
![tmp](https://user-images.githubusercontent.com/35496058/197651437-fb07a6a6-b31d-4ebe-8cf5-db622b7f785a.PNG)
