### PR TITLE
feat(admin): move draft order reset to success method

### DIFF
--- a/src/components/molecules/modal/stepped-modal.tsx
+++ b/src/components/molecules/modal/stepped-modal.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx"
 import React, { ReactNode, useReducer } from "react"
+import useToggleState from "../../../hooks/use-toggle-state"
 import Button from "../../fundamentals/button"
 import Modal, { ModalProps } from "../../molecules/modal"
 import LayeredModal, { ILayeredModalContext } from "./layered-modal"
@@ -136,7 +137,6 @@ const SteppedModal: React.FC<SteppedProps> = ({
 
   const resetAndSubmit = () => {
     onSubmit()
-    context.reset()
   }
   return (
     <ModalElement

--- a/src/domain/orders/new/new-order.tsx
+++ b/src/domain/orders/new/new-order.tsx
@@ -104,6 +104,7 @@ const NewOrder = ({ onDismiss }: NewOrderProps) => {
           notification("Success", "Order created", "success")
           reset()
           onDismiss()
+          steppedContext.reset()
           navigate(`/a/draft-orders/${draft_order.id}`)
         },
         onError: (error) => {


### PR DESCRIPTION
Prevent resetting stepped modal before submission is finished:

https://user-images.githubusercontent.com/88927411/199168969-50284840-78f9-46bc-835d-361a27c15d28.mov

