### PR TITLE
Fix: use day of month rather than day of week

### DIFF
--- a/.changeset/new-maps-breathe.md
+++ b/.changeset/new-maps-breathe.md
@@ -1,5 +1,0 @@
----
-"@fake-scope/fake-pkg": patch
----
-
-Fix: use day of month rather than day of week

--- a/.changeset/new-maps-breathe.md
+++ b/.changeset/new-maps-breathe.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Fix: use day of month rather than day of week

--- a/src/domain/orders/details/index.tsx
+++ b/src/domain/orders/details/index.tsx
@@ -292,7 +292,7 @@ const OrderDetails = ({ id }: OrderDetailProps) => {
                     </Tooltip>
                   }
                   subtitle={moment(order.created_at).format(
-                    "d MMMM YYYY hh:mm a"
+                    "D MMMM YYYY hh:mm a"
                   )}
                   status={<OrderStatusComponent status={order.status} />}
                   forceDropdown={true}


### PR DESCRIPTION
**What**
- Show the correct date in order detail

**How**
- update the formatting string to display day of month, previously it displayed day of week by number

**Testing**
- open an order with a date placed > 7 and verify that it has the correct date

https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/

Fixes CORE-694