### PR TITLE
fix: draft order and order display the item price incorrectly when includes taxes

### DIFF
--- a/src/domain/orders/details/order-line/index.tsx
+++ b/src/domain/orders/details/order-line/index.tsx
@@ -36,10 +36,10 @@ const OrderLine = ({ item, currencyCode }: OrderLineProps) => {
         <div className="flex small:space-x-2 medium:space-x-4 large:space-x-6 mr-3">
           <div className="inter-small-regular text-grey-50">
             {formatAmountWithSymbol({
-              amount: item.unit_price,
+              amount: (item?.total ?? 0) / item.quantity,
               currency: currencyCode,
               digits: 2,
-              tax: item.tax_lines,
+              tax: [],
             })}
           </div>
           <div className="inter-small-regular text-grey-50">
@@ -47,10 +47,10 @@ const OrderLine = ({ item, currencyCode }: OrderLineProps) => {
           </div>
           <div className="inter-small-regular text-grey-90">
             {formatAmountWithSymbol({
-              amount: item.unit_price * item.quantity,
+              amount: item.total ?? 0,
               currency: currencyCode,
               digits: 2,
-              tax: item.tax_lines,
+              tax: [],
             })}
           </div>
         </div>

--- a/src/domain/orders/draft-orders/details.tsx
+++ b/src/domain/orders/draft-orders/details.tsx
@@ -246,10 +246,10 @@ const DraftOrderDetails = ({ id }: DraftOrderDetailsProps) => {
                       <div className="flex small:space-x-2 medium:space-x-4 large:space-x-6 mr-3">
                         <div className="inter-small-regular text-grey-50">
                           {formatAmountWithSymbol({
-                            amount: item.unit_price,
-                            currency: region?.currency_code,
+                            amount: (item?.total ?? 0) / item.quantity,
+                            currency: region?.currency_code ?? "",
                             digits: 2,
-                            tax: region?.tax_rate,
+                            tax: [],
                           })}
                         </div>
                         <div className="inter-small-regular text-grey-50">
@@ -257,10 +257,10 @@ const DraftOrderDetails = ({ id }: DraftOrderDetailsProps) => {
                         </div>
                         <div className="inter-small-regular text-grey-90">
                           {formatAmountWithSymbol({
-                            amount: item.unit_price * item.quantity,
-                            currency: region?.currency_code,
+                            amount: item.total ?? 0,
+                            currency: region?.currency_code ?? "",
                             digits: 2,
-                            tax: region?.tax_rate,
+                            tax: [],
                           })}
                         </div>
                       </div>


### PR DESCRIPTION
The server return now the totals on each item of and order and cart. Use this value to display the correct amount in the order and draft order details and do not rely on the taxes locally.

depends on https://github.com/medusajs/medusa/pull/2546

FIXES CORE-687