### PR TITLE
feat: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:18-slim
+
+RUN apt-get update && apt-get install python3 make g++ -y
+
+RUN npm install -g gatsby-cli
+
+WORKDIR /app
+
+COPY package.json yarn.lock /app/
+
+RUN yarn install
+
+RUN yarn build
+
+COPY . /app/
+
+EXPOSE 7000
+
+CMD ["gatsby", "develop", "-H", "0.0.0.0", "-p", "7000"]


### PR DESCRIPTION
Adds a Dockerfile, allowing the project to be started inside a Docker container

Solves #765

You can run this Dockerfile using docker-compose, or 

```docker run -p 7000:7000 -e GATSBY_MEDUSA_BACKEND_URL='https://your.medusa.backend.url' <IMAGE>```

> Remember to specify the `GATSBY_MEDUSA_BACKEND_URL` env variable, and have your desired ports accessible from the host machine.