### PR TITLE
Remove sneaky @reach/router usage

### DIFF
--- a/src/components/molecules/modal/focus-modal.tsx
+++ b/src/components/molecules/modal/focus-modal.tsx
@@ -5,6 +5,7 @@ import CrossIcon from "../../fundamentals/icons/cross-icon"
 
 type FocusModalElementProps = {
   className?: string
+  children?: React.ReactNode
 }
 
 type FocusModalProps = React.FC<FocusModalElementProps> & {
@@ -18,6 +19,7 @@ type BasicFocusModalProps = {
   onSubmit: (e) => void
   cancelText?: string
   submitText?: string
+  children?: React.ReactNode
 }
 
 const FocusModal: FocusModalProps = ({ className, children }) => (

--- a/src/domain/discounts/new/discount-form/index.tsx
+++ b/src/domain/discounts/new/discount-form/index.tsx
@@ -1,4 +1,3 @@
-import { Discount } from "@medusajs/medusa"
 import * as React from "react"
 import { useWatch } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
@@ -19,18 +18,10 @@ import DiscountType from "./sections/discount-type"
 import General from "./sections/general"
 
 type DiscountFormProps = {
-  discount?: Discount
-  isEdit?: boolean
-  additionalOpen?: string[]
   closeForm?: () => void
 }
 
-const DiscountForm: React.FC<DiscountFormProps> = ({
-  discount,
-  closeForm,
-  additionalOpen = [],
-  isEdit = false,
-}) => {
+const DiscountForm = ({ closeForm }: DiscountFormProps) => {
   const navigate = useNavigate()
   const notification = useNotification()
   const { handleSubmit, handleReset, control } = useDiscountForm()
@@ -47,19 +38,14 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
   }
 
   const submitGhost = async (data: DiscountFormValues) => {
-    if (!isEdit) {
-      onSaveAsInactive(data)
-        .then(() => {
-          closeFormModal()
-          handleReset()
-        })
-        .catch((error) => {
-          notification("Error", getErrorMessage(error), "error")
-        })
-    } else {
-      closeFormModal()
-      handleReset()
-    }
+    onSaveAsInactive(data)
+      .then(() => {
+        closeFormModal()
+        handleReset()
+      })
+      .catch((error) => {
+        notification("Error", getErrorMessage(error), "error")
+      })
   }
 
   const submitCTA = async (data: DiscountFormValues) => {
@@ -104,7 +90,7 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
               onClick={handleSubmit(submitCTA)}
               className="rounded-rounded"
             >
-              {isEdit ? "Save changes" : "Publish discount"}
+              Publish discount
             </Button>
           </div>
         </div>
@@ -112,12 +98,10 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
       <FocusModal.Main>
         <div className="flex justify-center mb-[25%]">
           <div className="max-w-[700px] w-full pt-16">
-            <h1 className="inter-xlarge-semibold">
-              {isEdit ? "Edit discount" : "Create new discount"}
-            </h1>
+            <h1 className="inter-xlarge-semibold">Create new discount</h1>
             <Accordion
               className="pt-7 text-grey-90"
-              defaultValue={["discount-type", ...additionalOpen]}
+              defaultValue={["discount-type"]}
               type="multiple"
             >
               <Accordion.Item
@@ -143,7 +127,7 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
                 value="general"
                 forceMountContent
               >
-                <General discount={discount} />
+                <General />
               </Accordion.Item>
               <Accordion.Item
                 forceMountContent
@@ -151,7 +135,7 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
                 value="configuration"
                 description="Discount code applies from you hit the publish button and forever if left untouched."
               >
-                <Configuration promotion={discount} isEdit={isEdit} />
+                <Configuration />
               </Accordion.Item>
               <Accordion.Item
                 forceMountContent
@@ -160,7 +144,7 @@ const DiscountForm: React.FC<DiscountFormProps> = ({
                 value="conditions"
                 tooltip="Add conditions to your Discount"
               >
-                <DiscountNewConditions discount={discount} />
+                <DiscountNewConditions />
               </Accordion.Item>
             </Accordion>
           </div>

--- a/src/domain/discounts/new/index.tsx
+++ b/src/domain/discounts/new/index.tsx
@@ -1,16 +1,11 @@
-import { Discount } from "@medusajs/medusa"
-import { useLocation } from "react-router-dom"
 import DiscountForm from "./discount-form"
 import { DiscountFormProvider } from "./discount-form/form/discount-form-context"
 
 const New = () => {
-  const location = useLocation()
-  const toDuplicate = location?.state?.discount as Discount | undefined
-
   return (
     <div className="pb-xlarge">
       <DiscountFormProvider>
-        <DiscountForm discount={toDuplicate} />
+        <DiscountForm />
       </DiscountFormProvider>
     </div>
   )

--- a/src/domain/discounts/new/index.tsx
+++ b/src/domain/discounts/new/index.tsx
@@ -1,10 +1,9 @@
 import { Discount } from "@medusajs/medusa"
-import { useLocation } from "@reach/router"
-import React from "react"
+import { useLocation } from "react-router-dom"
 import DiscountForm from "./discount-form"
 import { DiscountFormProvider } from "./discount-form/form/discount-form-context"
 
-const New: React.FC = () => {
+const New = () => {
   const location = useLocation()
   const toDuplicate = location?.state?.discount as Discount | undefined
 


### PR DESCRIPTION
Seems like a `"@reach/router"` import snug in or was missed when resolving merge from #800 to #802.

I've kept the usage of `location.state?`, though based on a quick code search, I don't see this being set or used anywhere else. May be stale code and safe to remove?