### PR TITLE
fix: remount of OE modal

### DIFF
--- a/src/domain/orders/edit/modal.tsx
+++ b/src/domain/orders/edit/modal.tsx
@@ -413,8 +413,6 @@ function OrderEditModalContainer(props: OrderEditModalContainerProps) {
     hideModal()
   }
 
-  console.log("rendered")
-
   if (!orderEdit) {
     return null
   }

--- a/src/domain/orders/edit/modal.tsx
+++ b/src/domain/orders/edit/modal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react"
+import React, { useContext, useEffect, useRef, useState } from "react"
 import { Order, OrderEdit, ProductVariant } from "@medusajs/medusa"
 import {
   useAdminCreateOrderEdit,
@@ -172,10 +172,8 @@ function OrderEditModal(props: OrderEditModalProps) {
     isLoading: isRequestingConfirmation,
   } = useAdminRequestOrderEditConfirmation(orderEdit.id)
 
-  const {
-    mutateAsync: updateOrderEdit,
-    isLoading: isUpdating,
-  } = useAdminUpdateOrderEdit(orderEdit.id)
+  const { mutateAsync: updateOrderEdit, isLoading: isUpdating } =
+    useAdminUpdateOrderEdit(orderEdit.id)
 
   const { mutateAsync: deleteOrderEdit } = useAdminDeleteOrderEdit(orderEdit.id)
 
@@ -371,21 +369,26 @@ function OrderEditModalContainer(props: OrderEditModalContainerProps) {
   const { order } = props
   const notification = useNotification()
 
-  const {
-    hideModal,
-    orderEdits,
-    activeOrderEditId,
-    setActiveOrderEdit,
-  } = useContext(OrderEditContext)
+  const isFirstRun = useRef(true)
+
+  const { hideModal, orderEdits, activeOrderEditId, setActiveOrderEdit } =
+    useContext(OrderEditContext)
 
   const { mutate: createOrderEdit } = useAdminCreateOrderEdit()
 
   const orderEdit = orderEdits?.find((oe) => oe.id === activeOrderEditId)
 
   useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false
+      return
+    }
+
     if (activeOrderEditId) {
       return
     }
+
+    isFirstRun.current = false
 
     createOrderEdit(
       { order_id: order.id },
@@ -403,12 +406,14 @@ function OrderEditModalContainer(props: OrderEditModalContainerProps) {
         },
       }
     )
-  }, [activeOrderEditId, orderEdits])
+  }, [activeOrderEditId])
 
   const onClose = () => {
     setActiveOrderEdit(undefined)
     hideModal()
   }
+
+  console.log("rendered")
 
   if (!orderEdit) {
     return null

--- a/src/domain/orders/edit/modal.tsx
+++ b/src/domain/orders/edit/modal.tsx
@@ -384,21 +384,18 @@ function OrderEditModalContainer(props: OrderEditModalContainerProps) {
     }
 
     isRequestRunningFlag = true
-    ;(async function () {
-      try {
-        const { order_edit } = await createOrderEdit({ order_id: order.id })
-        setActiveOrderEdit(order_edit.id)
-      } catch (e) {
+
+    createOrderEdit({ order_id: order.id })
+      .then(({ order_edit }) => setActiveOrderEdit(order_edit.id))
+      .catch(() => {
         notification(
           "Error",
-          "There is already active order edit on this order",
+          "There is already an active order edit on this order",
           "error"
         )
         hideModal()
-      } finally {
-        isRequestRunningFlag = false
-      }
-    })()
+      })
+      .finally(() => (isRequestRunningFlag = false))
   }, [activeOrderEditId])
 
   const onClose = () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,8 +12,6 @@ import App from "./App"
 import { FeatureFlagProvider } from "./context/feature-flag"
 import { SteppedProvider } from "./components/molecules/modal/stepped-modal"
 import { LayeredModalProvider } from "./components/molecules/modal/layered-modal"
-import AnalyticsProvider from "./context/analytics"
-import { WRITE_KEY } from "./components/constants/analytics"
 
 const Page = ({ children }: PropsWithChildren) => {
   return (


### PR DESCRIPTION
**What**
- the issue manifested in the order timeline which displayed (multiple) "created" order edit events

**Why**
- when we open the OE modal, a POST request is dispatched that will create a new OE on the order - this is done in an `useEffect` hook on mount
- if the newly upgraded React 18 is run in [strict mode](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-strict-mode), mount effects will be called twice (i.e. each component will be mounted, unmounted and mounted again)
- this will cause the creation of two order edits, and while the second one is being deleted when the modal is closed, first one still exists

**How**
- the fix is to only dispatch POST request on the first mount

---

FIXES CORE-840