### PR TITLE
chore: fix deploy directory for Netlify button

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,5 @@
 [template.environment]
 MEDUSA_BACKEND_URL="URL of your Medusa Server"
+
+[build]
+  publish = "public/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [template.environment]
-MEDUSA_BACKEND_URL="URL of your Medusa Server"
+  MEDUSA_BACKEND_URL="URL of your Medusa Server"
 
 [build]
   publish = "public/"


### PR DESCRIPTION
Fixed deploy directory of the Netlify button to publish the `public` directory following the change to vite.