### PR TITLE
add node.js version to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,4 @@
 
 [build]
   publish = "public/"
+  NODE_VERSION=14.8


### PR DESCRIPTION
Since Vite 3 requires node.js version 14.8+ or 16+, I've added a node version to `netlify.toml` to ensure the correct Node.js version is selected.