### PR TITLE
fix: OE "declined" timeline event

### DIFF
--- a/src/components/molecules/timeline-events/order-edit/confirmed.tsx
+++ b/src/components/molecules/timeline-events/order-edit/confirmed.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { OrderEditEvent } from "../../../../hooks/use-build-timeline"
 import FastDeliveryIcon from "../../../fundamentals/icons/fast-delivery-icon"
 import EventContainer from "../event-container"
+import { isConfirmedByUser } from "../../../../domain/orders/edit/utils/user"
 import { ByLine } from "."
 
 type ConfirmedProps = {
@@ -11,7 +12,7 @@ type ConfirmedProps = {
 }
 
 const EditConfirmed: React.FC<ConfirmedProps> = ({ event }) => {
-  const confirmedByAdmin = event.edit.confirmed_by?.startsWith("usr")
+  const confirmedByAdmin = isConfirmedByUser(event.edit)
 
   const title = `Order Edit ${
     !confirmedByAdmin ? "confirmation accepted" : "force confirmed"

--- a/src/components/molecules/timeline-events/order-edit/declined.tsx
+++ b/src/components/molecules/timeline-events/order-edit/declined.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { OrderEditEvent } from "../../../../hooks/use-build-timeline"
 import XCircleIcon from "../../../fundamentals/icons/x-circle-icon"
 import EventContainer from "../event-container"
+import { isDeclinedByUser } from "../../../../domain/orders/edit/utils/user"
 import { ByLine } from "."
 
 type EditDeclinedProps = {
@@ -13,7 +14,7 @@ type EditDeclinedProps = {
 const EditDeclined: React.FC<EditDeclinedProps> = ({ event }) => {
   const { order_edit: orderEdit } = useAdminOrderEdit(event.edit.id)
 
-  const declinedByAdmin = event.edit.declined_by?.startsWith("usr")
+  const declinedByAdmin = isDeclinedByUser(event.edit)
 
   const { user } = useAdminUser(event.edit.declined_by as string, {
     enabled: declinedByAdmin && !!event.edit.declined_by,

--- a/src/components/molecules/timeline-events/order-edit/declined.tsx
+++ b/src/components/molecules/timeline-events/order-edit/declined.tsx
@@ -23,9 +23,7 @@ const EditDeclined: React.FC<EditDeclinedProps> = ({ event }) => {
     enabled: !declinedByAdmin && !!event.edit.declined_by,
   })
 
-  const note = declinedByAdmin
-    ? orderEdit?.internal_note
-    : orderEdit?.declined_reason
+  const note = orderEdit?.declined_reason
 
   return (
     <EventContainer

--- a/src/components/molecules/timeline-events/order-edit/declined.tsx
+++ b/src/components/molecules/timeline-events/order-edit/declined.tsx
@@ -1,16 +1,31 @@
-import { useAdminCustomer } from "medusa-react"
+import { useAdminCustomer, useAdminOrderEdit, useAdminUser } from "medusa-react"
 import React from "react"
-import { ByLine } from "."
+
 import { OrderEditEvent } from "../../../../hooks/use-build-timeline"
 import XCircleIcon from "../../../fundamentals/icons/x-circle-icon"
 import EventContainer from "../event-container"
+import { ByLine } from "."
 
 type EditDeclinedProps = {
   event: OrderEditEvent
 }
 
 const EditDeclined: React.FC<EditDeclinedProps> = ({ event }) => {
-  const { customer } = useAdminCustomer(event.edit.declined_by as string)
+  const { order_edit: orderEdit } = useAdminOrderEdit(event.edit.id)
+
+  const declinedByAdmin = event.edit.declined_by?.startsWith("usr")
+
+  const { user } = useAdminUser(event.edit.declined_by as string, {
+    enabled: declinedByAdmin && !!event.edit.declined_by,
+  })
+
+  const { customer } = useAdminCustomer(event.edit.declined_by as string, {
+    enabled: !declinedByAdmin && !!event.edit.declined_by,
+  })
+
+  const note = declinedByAdmin
+    ? orderEdit?.internal_note
+    : orderEdit?.declined_reason
 
   return (
     <EventContainer
@@ -18,8 +33,14 @@ const EditDeclined: React.FC<EditDeclinedProps> = ({ event }) => {
       icon={<XCircleIcon size={20} />}
       time={event.time}
       isFirst={event.first}
-      midNode={<ByLine user={customer} />}
-    />
+      midNode={<ByLine user={customer || user} />}
+    >
+      {note && (
+        <div className="px-base py-small mt-base rounded-large bg-grey-10 inter-base-regular text-grey-90">
+          {note}
+        </div>
+      )}
+    </EventContainer>
   )
 }
 

--- a/src/domain/orders/edit/utils/user.ts
+++ b/src/domain/orders/edit/utils/user.ts
@@ -1,0 +1,19 @@
+import { OrderEdit } from "@medusajs/medusa"
+
+const USER_PREFIX = "usr"
+
+/**
+ * Returns true if the order edit has been declined by an admin.
+ */
+function isDeclinedByUser(edit: OrderEdit) {
+  return !!edit.declined_by?.startsWith(USER_PREFIX)
+}
+
+/**
+ * Returns true if the order edit has been confirmed by an admin.
+ */
+function isConfirmedByUser(edit: OrderEdit) {
+  return !!edit.confirmed_by?.startsWith(USER_PREFIX)
+}
+
+export { isConfirmedByUser, isDeclinedByUser }


### PR DESCRIPTION
**What**
- fix the "Order declined" timeline event declined reason display
- properly fetch user/customer that declined the edit

---

FIXES CORE-883