### PR TITLE
feat: Initial sidebar redesign

### DIFF
--- a/src/components/atoms/avatar/index.tsx
+++ b/src/components/atoms/avatar/index.tsx
@@ -38,7 +38,7 @@ const Avatar: React.FC<AvatarProps> = ({
       <RadixAvatar.Image
         src={user?.img}
         alt={username}
-        className="w-full h-full object-cover rounded-circle"
+        className="object-cover w-full h-full rounded-circle"
       />
       <RadixAvatar.Fallback
         className={clsx(

--- a/src/components/fundamentals/icons/cart-icon/cart-icon.stories.tsx
+++ b/src/components/fundamentals/icons/cart-icon/cart-icon.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta } from "@storybook/react"
 import CartIcon from "."
 
-export default {
+const cartIconComponentMeta: ComponentMeta<typeof CartIcon> = {
   title: "Fundamentals/Icons/CartIcon",
   component: CartIcon,
   argTypes: {
@@ -12,7 +12,9 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof CartIcon>
+}
+
+export default cartIconComponentMeta
 
 const Template = (args) => <CartIcon {...args} />
 

--- a/src/components/fundamentals/icons/cart-icon/cart-icon.stories.tsx
+++ b/src/components/fundamentals/icons/cart-icon/cart-icon.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta } from "@storybook/react"
+import CartIcon from "."
+
+export default {
+  title: "Fundamentals/Icons/CartIcon",
+  component: CartIcon,
+  argTypes: {
+    size: {
+      control: {
+        type: "select",
+        options: ["24", "20", "16"],
+      },
+    },
+  },
+} as ComponentMeta<typeof CartIcon>
+
+const Template = (args) => <CartIcon {...args} />
+
+export const Icon = Template.bind({})
+Icon.args = {
+  size: "24",
+  color: "currentColor",
+}

--- a/src/components/fundamentals/icons/cart-icon/index.tsx
+++ b/src/components/fundamentals/icons/cart-icon/index.tsx
@@ -18,30 +18,30 @@ const CartIcon: React.FC<IconProps> = ({
       <path
         d="M5.70291 11.7848L4.18457 5.34766H16.6736C17.3175 5.34766 17.7893 5.89045 17.633 6.45189L16.2997 11.242C16.0969 11.9695 15.4084 12.5043 14.5776 12.579L7.83552 13.1848C6.83054 13.2745 5.91162 12.6713 5.70291 11.7848V11.7848Z"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M4.18418 5.34722L3.54123 2.68213H1.83594"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M14.2117 15.7988C13.7978 15.7988 13.4618 16.1349 13.4659 16.5488C13.4659 16.9628 13.8019 17.2988 14.2158 17.2988C14.6298 17.2988 14.9658 16.9628 14.9658 16.5488C14.9638 16.1349 14.6277 15.7988 14.2117 15.7988Z"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M7.20104 15.7988C6.78655 15.7988 6.45003 16.1344 6.45414 16.5478C6.45003 16.9632 6.7886 17.2988 7.20309 17.2988C7.61758 17.2988 7.9541 16.9632 7.9541 16.5499C7.9541 16.1344 7.61758 15.7988 7.20104 15.7988Z"
         stroke={color}
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   )

--- a/src/components/fundamentals/icons/cart-icon/index.tsx
+++ b/src/components/fundamentals/icons/cart-icon/index.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+import IconProps from "../types/icon-type"
+
+const CartIcon: React.FC<IconProps> = ({
+  size = "24",
+  color = "currentColor",
+  ...attributes
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...attributes}
+    >
+      <path
+        d="M5.70291 11.7848L4.18457 5.34766H16.6736C17.3175 5.34766 17.7893 5.89045 17.633 6.45189L16.2997 11.242C16.0969 11.9695 15.4084 12.5043 14.5776 12.579L7.83552 13.1848C6.83054 13.2745 5.91162 12.6713 5.70291 11.7848V11.7848Z"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M4.18418 5.34722L3.54123 2.68213H1.83594"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M14.2117 15.7988C13.7978 15.7988 13.4618 16.1349 13.4659 16.5488C13.4659 16.9628 13.8019 17.2988 14.2158 17.2988C14.6298 17.2988 14.9658 16.9628 14.9658 16.5488C14.9638 16.1349 14.6277 15.7988 14.2117 15.7988Z"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M7.20104 15.7988C6.78655 15.7988 6.45003 16.1344 6.45414 16.5478C6.45003 16.9632 6.7886 17.2988 7.20309 17.2988C7.61758 17.2988 7.9541 16.9632 7.9541 16.5499C7.9541 16.1344 7.61758 15.7988 7.20104 15.7988Z"
+        stroke={color}
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+export default CartIcon

--- a/src/components/molecules/notification-bell/index.tsx
+++ b/src/components/molecules/notification-bell/index.tsx
@@ -12,7 +12,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
   ...attributes
 }) => {
   return (
-    <Button className="w-8 h-8 mr-3" size="small" {...attributes}>
+    <Button className="w-8 h-8" size="small" {...attributes}>
       {hasNotifications ? <BellNotiIcon /> : <BellIcon />}
     </Button>
   )

--- a/src/components/molecules/sidebar-menu-item/index.tsx
+++ b/src/components/molecules/sidebar-menu-item/index.tsx
@@ -15,7 +15,9 @@ type SidebarMenuItemProps = {
   subItems?: SidebarMenuSubitemProps[]
 }
 
-const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({
+const SidebarMenuItem: React.FC<SidebarMenuItemProps> & {
+  SubItem: (props: SidebarMenuSubitemProps) => JSX.Element
+} = ({
   pageLink,
   icon,
   text,
@@ -23,8 +25,8 @@ const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({
   subItems = [],
 }: SidebarMenuItemProps) => {
   const styles =
-    "py-1.5 px-3 my-0.5 rounded-base flex text-grey-90 hover:bg-grey-10 items-center"
-  const activeStyles = "bg-grey-10 text-violet-50"
+    "group py-1.5 my-0.5 rounded-rounded flex text-grey-50 hover:bg-grey-10 items-center px-2"
+  const activeStyles = "bg-grey-10 is-active"
   const classNameFn = useCallback(
     ({ isActive }) => (isActive ? `${styles} ${activeStyles}` : styles),
     []
@@ -38,7 +40,7 @@ const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({
       trigger={
         <NavLink className={classNameFn} to={pageLink}>
           <span className="items-start">{icon}</span>
-          <span className="ml-3">{text}</span>
+          <span className="ml-3 group-[.is-active]:text-grey-90">{text}</span>
         </NavLink>
       }
     >
@@ -60,7 +62,7 @@ const SubItem = ({ pageLink, text }: SidebarMenuSubitemProps) => {
 
   return (
     <NavLink className={classNameFn} to={pageLink}>
-      <span className="text-grey-90 text-small ml-3">{text}</span>
+      <span className="ml-3 text-grey-90 text-small">{text}</span>
     </NavLink>
   )
 }

--- a/src/components/molecules/user-menu/index.tsx
+++ b/src/components/molecules/user-menu/index.tsx
@@ -1,0 +1,60 @@
+import React, { useContext } from "react"
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import Avatar from "../../atoms/avatar"
+import Button from "../../fundamentals/button"
+import GearIcon from "../../fundamentals/icons/gear-icon"
+import SignOutIcon from "../../fundamentals/icons/log-out-icon"
+import { useNavigate } from "react-router-dom"
+import { AccountContext } from "../../../context/account"
+
+const UserMenu: React.FC = () => {
+  const navigate = useNavigate()
+  const { first_name, last_name, email, handleLogout } =
+    useContext(AccountContext)
+
+  const logOut = () => {
+    handleLogout()
+    navigate("/login")
+  }
+  return (
+    <div className="w-large h-large">
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <div className="w-full h-full cursor-pointer">
+            <Avatar
+              user={{ first_name, last_name, email }}
+              color="bg-fuschia-40"
+            />
+          </div>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content
+          sideOffset={5}
+          className="border bg-grey-0 border-grey-20 rounded-rounded shadow-dropdown p-xsmall min-w-[200px] z-30"
+        >
+          <DropdownMenu.Item className="mb-1 last:mb-0">
+            <Button
+              variant="ghost"
+              size="small"
+              className={"w-full justify-start"}
+              onClick={() => navigate("/a/settings")}
+            >
+              <GearIcon />
+              Settings
+            </Button>
+            <Button
+              variant="ghost"
+              size="small"
+              className={"w-full justify-start text-rose-50"}
+              onClick={() => logOut()}
+            >
+              <SignOutIcon size={20} />
+              Sign out
+            </Button>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </div>
+  )
+}
+
+export default UserMenu

--- a/src/components/organisms/sidebar/index.tsx
+++ b/src/components/organisms/sidebar/index.tsx
@@ -44,6 +44,12 @@ const Sidebar: React.FC = () => {
         </div>
         <div className="py-3.5">
           <SidebarMenuItem
+            pageLink={"/a/orders"}
+            icon={<CartIcon size={ICON_SIZE} />}
+            triggerHandler={triggerHandler}
+            text={"Orders"}
+          />
+          <SidebarMenuItem
             pageLink={"/a/products"}
             icon={<TagIcon size={ICON_SIZE} />}
             text={"Products"}
@@ -56,16 +62,10 @@ const Sidebar: React.FC = () => {
             text={"Customers"}
           />
           <SidebarMenuItem
-            pageLink={"/a/orders"}
-            icon={<CartIcon size={ICON_SIZE} />}
-            triggerHandler={triggerHandler}
-            text={"Orders"}
-          />
-          <SidebarMenuItem
             pageLink={"/a/discounts"}
             icon={<SaleIcon size={ICON_SIZE} />}
             triggerHandler={triggerHandler}
-            text={"Promotions"}
+            text={"Discounts"}
           />
           <SidebarMenuItem
             pageLink={"/a/gift-cards"}

--- a/src/components/organisms/sidebar/index.tsx
+++ b/src/components/organisms/sidebar/index.tsx
@@ -1,16 +1,16 @@
 import { useAdminStore } from "medusa-react"
 import React, { useState } from "react"
+import CartIcon from "../../fundamentals/icons/cart-icon"
 import CashIcon from "../../fundamentals/icons/cash-icon"
-import CustomerIcon from "../../fundamentals/icons/customer-icon"
-import DollarSignIcon from "../../fundamentals/icons/dollar-sign-icon"
 import GearIcon from "../../fundamentals/icons/gear-icon"
 import GiftIcon from "../../fundamentals/icons/gift-icon"
 import SaleIcon from "../../fundamentals/icons/sale-icon"
 import TagIcon from "../../fundamentals/icons/tag-icon"
-import SidebarCompanyLogo from "../../molecules/sidebar-company-logo"
+import UsersIcon from "../../fundamentals/icons/users-icon"
 import SidebarMenuItem from "../../molecules/sidebar-menu-item"
+import UserMenu from "../../molecules/user-menu"
 
-const ICON_SIZE = 18
+const ICON_SIZE = 20
 
 const Sidebar: React.FC = () => {
   const [currentlyOpen, setCurrentlyOpen] = useState(-1)
@@ -29,17 +29,20 @@ const Sidebar: React.FC = () => {
   triggerHandler.id = 0
 
   return (
-    <div className="min-w-sidebar max-w-sidebar h-screen overflow-y-auto bg-gray-0 border-r border-grey-20 py-base px-base">
-      <div className="h-full ">
-        <SidebarCompanyLogo storeName={store?.name} />
-
-        <div className="border-b pb-3.5 border-grey-20">
-          <SidebarMenuItem
-            pageLink={"/a/orders"}
-            icon={<DollarSignIcon size={ICON_SIZE} />}
-            triggerHandler={triggerHandler}
-            text={"Orders"}
-          />
+    <div className="h-screen overflow-y-auto border-r min-w-sidebar max-w-sidebar bg-gray-0 border-grey-20 py-base px-base">
+      <div className="h-full">
+        <div className="flex justify-between px-2">
+          <div className="flex items-center justify-center w-8 h-8 border border-gray-300 border-solid rounded-circle">
+            <UserMenu />
+          </div>
+        </div>
+        <div className="flex flex-col px-2 my-base">
+          <span className="font-medium text-grey-50 text-small">Store</span>
+          <span className="font-medium text-grey-90 text-medium">
+            {store?.name}
+          </span>
+        </div>
+        <div className="py-3.5">
           <SidebarMenuItem
             pageLink={"/a/products"}
             icon={<TagIcon size={ICON_SIZE} />}
@@ -48,15 +51,21 @@ const Sidebar: React.FC = () => {
           />
           <SidebarMenuItem
             pageLink={"/a/customers"}
-            icon={<CustomerIcon size={ICON_SIZE} />}
+            icon={<UsersIcon size={ICON_SIZE} />}
             triggerHandler={triggerHandler}
             text={"Customers"}
+          />
+          <SidebarMenuItem
+            pageLink={"/a/orders"}
+            icon={<CartIcon size={ICON_SIZE} />}
+            triggerHandler={triggerHandler}
+            text={"Orders"}
           />
           <SidebarMenuItem
             pageLink={"/a/discounts"}
             icon={<SaleIcon size={ICON_SIZE} />}
             triggerHandler={triggerHandler}
-            text={"Discounts"}
+            text={"Promotions"}
           />
           <SidebarMenuItem
             pageLink={"/a/gift-cards"}

--- a/src/components/organisms/topbar/index.tsx
+++ b/src/components/organisms/topbar/index.tsx
@@ -1,43 +1,28 @@
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import React, {
   type MouseEvent,
   useCallback,
   useContext,
   useState,
 } from "react"
-import { useNavigate } from "react-router-dom"
-import { AccountContext } from "../../../context/account"
 import { PollingContext } from "../../../context/polling"
 import useToggleState from "../../../hooks/use-toggle-state"
-import Avatar from "../../atoms/avatar"
 import Button from "../../fundamentals/button"
-import GearIcon from "../../fundamentals/icons/gear-icon"
 import HelpCircleIcon from "../../fundamentals/icons/help-circle"
-import SignOutIcon from "../../fundamentals/icons/log-out-icon"
 import NotificationBell from "../../molecules/notification-bell"
 import SearchBar from "../../molecules/search-bar"
 import ActivityDrawer from "../activity-drawer"
 import MailDialog from "../help-dialog"
 
 const Topbar: React.FC = () => {
-  const navigate = useNavigate()
-
   const {
     state: activityDrawerState,
     toggle: toggleActivityDrawer,
     close: activityDrawerClose,
   } = useToggleState(false)
 
-  const { first_name, last_name, email, handleLogout } =
-    useContext(AccountContext)
   const { batchJobs } = useContext(PollingContext)
 
   const [showSupportform, setShowSupportForm] = useState(false)
-
-  const logOut = () => {
-    handleLogout()
-    navigate("/login")
-  }
 
   const onNotificationBellClick = useCallback(
     (event: MouseEvent) => {
@@ -48,7 +33,7 @@ const Topbar: React.FC = () => {
   )
 
   return (
-    <div className="w-full min-h-topbar max-h-topbar pr-xlarge pl-base bg-grey-0 border-b border-grey-20 sticky top-0 flex items-center justify-between z-40">
+    <div className="sticky top-0 z-40 flex items-center justify-between w-full border-b min-h-topbar max-h-topbar pr-xlarge pl-base bg-grey-0 border-grey-20">
       <SearchBar />
       <div className="flex items-center">
         <Button
@@ -65,44 +50,6 @@ const Topbar: React.FC = () => {
           variant={"ghost"}
           hasNotifications={!!batchJobs?.length}
         />
-
-        <div className="ml-large w-large h-large">
-          <DropdownMenu.Root>
-            <DropdownMenu.Trigger asChild>
-              <div className="cursor-pointer w-full h-full">
-                <Avatar
-                  user={{ first_name, last_name, email }}
-                  color="bg-fuschia-40"
-                />
-              </div>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content
-              sideOffset={5}
-              className="border bg-grey-0 border-grey-20 rounded-rounded shadow-dropdown p-xsmall min-w-[200px] z-30"
-            >
-              <DropdownMenu.Item className="mb-1 last:mb-0">
-                <Button
-                  variant="ghost"
-                  size="small"
-                  className={"w-full justify-start"}
-                  onClick={() => navigate("/a/settings")}
-                >
-                  <GearIcon />
-                  Settings
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="small"
-                  className={"w-full justify-start text-rose-50"}
-                  onClick={() => logOut()}
-                >
-                  <SignOutIcon size={20} />
-                  Sign out
-                </Button>
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
-        </div>
       </div>
       {showSupportform && (
         <MailDialog


### PR DESCRIPTION
**What/How/Why?**

Very first stage of sidebar redesign.

- Moved the avatar/user menu from the top bar to the sidebar (and to its own component in the process)
- Changed the store name display 
- Slight redesign of the menu items, dropped the purple from active items, changed the greys a little, made the active item background borders more rounded
- Re-ordered Products/Customers/Orders, updated some of the icons
- Renamed Discounts to Promotions

![image](https://user-images.githubusercontent.com/948623/210762795-b4dc07a4-eea2-476c-9079-48fbffb4a4e3.png)

As a sidenote, for most of my PRs updating files that contain tailwind classes: my linter re-orders the classes in what Tailwind considers the "correct" order. Makes some PRs a little more annoying to review, but have spoken to Oli and we'd like to move towards enforcing this linting rule repo-wide soon.

Closes CORE-951.