### PR TITLE
fix: duplicate variant fails due to `price.id` constraint

### DIFF
--- a/src/domain/products/edit/sections/variants/add-variant-modal.tsx
+++ b/src/domain/products/edit/sections/variants/add-variant-modal.tsx
@@ -1,5 +1,5 @@
 import { AdminPostProductsProductVariantsReq, Product } from "@medusajs/medusa"
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import Button from "../../../../../components/fundamentals/button"
 import Modal from "../../../../../components/molecules/modal"
@@ -123,7 +123,6 @@ export const createAddPayload = (
         amount: price.amount,
         currency_code: price.region_id ? undefined : price.currency_code,
         region_id: price.region_id,
-        id: price.id || undefined,
       }
     })
 

--- a/src/domain/products/edit/sections/variants/edit-variant-modal.tsx
+++ b/src/domain/products/edit/sections/variants/edit-variant-modal.tsx
@@ -1,5 +1,4 @@
 import { Product, ProductVariant } from "@medusajs/medusa"
-import React from "react"
 import { useForm } from "react-hook-form"
 import Button from "../../../../../components/fundamentals/button"
 import Modal from "../../../../../components/molecules/modal"
@@ -39,12 +38,8 @@ const EditVariantModal = ({
     onClose()
   }
 
-  const {
-    onUpdateVariant,
-    onAddVariant,
-    addingVariant,
-    updatingVariant,
-  } = useEditProductActions(product.id)
+  const { onUpdateVariant, onAddVariant, addingVariant, updatingVariant } =
+    useEditProductActions(product.id)
 
   const onSubmit = handleSubmit((data) => {
     if (isDuplicate) {

--- a/src/domain/products/edit/sections/variants/table.tsx
+++ b/src/domain/products/edit/sections/variants/table.tsx
@@ -1,5 +1,5 @@
 import { ProductVariant } from "@medusajs/medusa"
-import React, { useMemo } from "react"
+import { useMemo } from "react"
 import { Column, useTable } from "react-table"
 import DuplicateIcon from "../../../../../components/fundamentals/icons/duplicate-icon"
 import EditIcon from "../../../../../components/fundamentals/icons/edit-icon"
@@ -79,19 +79,14 @@ export const useVariantsTableColumns = () => {
 const VariantsTable = ({ variants, actions }: Props) => {
   const columns = useVariantsTableColumns()
 
-  const {
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    rows,
-    prepareRow,
-  } = useTable({
-    columns,
-    data: variants,
-    defaultColumn: {
-      width: "auto",
-    },
-  })
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+    useTable({
+      columns,
+      data: variants,
+      defaultColumn: {
+        width: "auto",
+      },
+    })
 
   const { deleteVariant, updateVariant, duplicateVariant } = actions
 


### PR DESCRIPTION
**What**
- Fixes an issue where duplicating a variant would result in an error due to a price with the provided ID already existing.
