### PR TITLE
hotfix: Dedup default sales channel on product creation

### DIFF
--- a/src/domain/products/new/index.tsx
+++ b/src/domain/products/new/index.tsx
@@ -1,6 +1,6 @@
 import { AdminPostProductsReq } from "@medusajs/medusa"
 import { useAdminCreateProduct } from "medusa-react"
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
 import Button from "../../../components/fundamentals/button"
@@ -296,14 +296,14 @@ const createPayload = (
     mid_code: data.customs.mid_code || undefined,
     type: data.organize.type
       ? {
-        value: data.organize.type.label,
-        id: data.organize.type.value,
-      }
+          value: data.organize.type.label,
+          id: data.organize.type.value,
+        }
       : undefined,
     tags: data.organize.tags
       ? data.organize.tags.map((t) => ({
-        value: t,
-      }))
+          value: t,
+        }))
       : undefined,
     origin_country: data.customs.origin_country?.value || undefined,
     options: data.variants.options.map((o) => ({


### PR DESCRIPTION
**What**
- Remove duplicated default sales channel entries in product sales channel array
- Use a flag to determine if users have removed the default sales channel from the product payload to prevent it from being re-added unless the user adds it themselves

Resolves CORE-1069