### PR TITLE
fix: Create DraftOrder flow

### DIFF
--- a/src/domain/orders/details/rma-sub-modals/products.tsx
+++ b/src/domain/orders/details/rma-sub-modals/products.tsx
@@ -11,7 +11,6 @@ import { LayeredModalContext } from "../../../../components/molecules/modal/laye
 import Table from "../../../../components/molecules/table"
 import TableContainer from "../../../../components/organisms/table-container"
 import { useDebounce } from "../../../../hooks/use-debounce"
-import { useNewOrderForm } from "../../new/form"
 
 const getProductStatusVariant = (status) => {
   switch (status) {
@@ -36,10 +35,6 @@ const RMASelectProductSubModal: React.FC<RMASelectProductSubModalProps> = ({
   onSubmit,
   selectedItems,
 }) => {
-  const {
-    context: { region },
-  } = useNewOrderForm()
-
   const PAGE_SIZE = 12
   const { pop } = useContext(LayeredModalContext)
   const [query, setQuery] = useState("")
@@ -55,7 +50,6 @@ const RMASelectProductSubModal: React.FC<RMASelectProductSubModalProps> = ({
     q: debouncedSearchTerm,
     limit: PAGE_SIZE,
     offset,
-    region_id: region?.id,
   })
 
   useEffect(() => {

--- a/src/domain/orders/new/components/items.tsx
+++ b/src/domain/orders/new/components/items.tsx
@@ -1,5 +1,4 @@
 import { Product, ProductVariant, Region } from "@medusajs/medusa"
-import { PricedVariant } from "@medusajs/medusa/dist/types/pricing"
 import clsx from "clsx"
 import React, { useContext, useEffect, useState } from "react"
 import { Controller } from "react-hook-form"
@@ -22,6 +21,7 @@ import {
 import RMASelectProductSubModal from "../../details/rma-sub-modals/products"
 import { useNewOrderForm } from "../form"
 import CustomItemSubModal from "./custom-item-sub-modal"
+import { PricedVariant } from "@medusajs/medusa/dist/types/pricing"
 
 const Items = () => {
   const { enableNextPage, disableNextPage, nextStepEnabled } =
@@ -40,17 +40,19 @@ const Items = () => {
   const layeredContext = useContext(LayeredModalContext)
 
   const addItem = async (variants: ProductVariant[]) => {
-    const variantIds = variants.map((v) => v.id)
+    const ids = fields.map((field) => field.variant_id)
+
+    const itemsToAdd = variants.filter((v) => !ids.includes(v.id))
+
+    const variantIds = itemsToAdd.map((v) => v.id)
+
     const { data } = (await Medusa.variants.list({
-      id: variantIds,
+      ["id[]"]: variantIds,
       region_id: region?.id,
     })) as unknown as { data: { variants: PricedVariant[] } }
 
-    const ids = fields.map((field) => field.variant_id)
-    const itemsToAdd = data.variants.filter((v) => !ids.includes(v.id))
-
     append(
-      itemsToAdd.map((item) => ({
+      data.variants.map((item) => ({
         quantity: 1,
         variant_id: item.id,
         title: item.title as string,

--- a/src/domain/orders/new/components/items.tsx
+++ b/src/domain/orders/new/components/items.tsx
@@ -2,7 +2,6 @@ import { Product, ProductVariant, Region } from "@medusajs/medusa"
 import clsx from "clsx"
 import React, { useContext, useEffect, useState } from "react"
 import { Controller } from "react-hook-form"
-import Medusa from "../../../../services/api"
 import Button from "../../../../components/fundamentals/button"
 import MinusIcon from "../../../../components/fundamentals/icons/minus-icon"
 import PlusIcon from "../../../../components/fundamentals/icons/plus-icon"
@@ -21,7 +20,7 @@ import {
 import RMASelectProductSubModal from "../../details/rma-sub-modals/products"
 import { useNewOrderForm } from "../form"
 import CustomItemSubModal from "./custom-item-sub-modal"
-import { PricedVariant } from "@medusajs/medusa/dist/types/pricing"
+import { useMedusa } from "medusa-react"
 
 const Items = () => {
   const { enableNextPage, disableNextPage, nextStepEnabled } =
@@ -29,8 +28,10 @@ const Items = () => {
 
   const {
     context: { region, items },
-    form: { control, register, setValue, getValues },
+    form: { control, register, setValue },
   } = useNewOrderForm()
+
+  const { client } = useMedusa()
 
   const { fields, append, remove, update } = items
 
@@ -46,13 +47,13 @@ const Items = () => {
 
     const variantIds = itemsToAdd.map((v) => v.id)
 
-    const { data } = (await Medusa.variants.list({
-      ["id[]"]: variantIds,
+    const { variants: newVariants } = await client.admin.variants.list({
+      id: variantIds,
       region_id: region?.id,
-    })) as unknown as { data: { variants: PricedVariant[] } }
+    })
 
     append(
-      data.variants.map((item) => ({
+      newVariants.map((item) => ({
         quantity: 1,
         variant_id: item.id,
         title: item.title as string,

--- a/src/domain/orders/new/components/select-region.tsx
+++ b/src/domain/orders/new/components/select-region.tsx
@@ -8,7 +8,9 @@ import { useNewOrderForm } from "../form"
 const SelectRegionScreen = () => {
   const { enableNextPage, disableNextPage } = React.useContext(SteppedContext)
 
-  const { control } = useNewOrderForm()
+  const {
+    form: { control },
+  } = useNewOrderForm()
 
   const reg = useWatch({
     control,

--- a/src/domain/orders/new/form/index.tsx
+++ b/src/domain/orders/new/form/index.tsx
@@ -119,7 +119,7 @@ const NewOrderFormProvider = ({ children }: { children?: ReactNode }) => {
         const variantIds = items.fields.map((v) => v.variant_id)
 
         const { data } = (await Medusa.variants.list({
-          id: variantIds,
+          ["id[]"]: variantIds,
           region_id: region?.id,
         })) as unknown as { data: { variants: PricedVariant[] } }
 

--- a/src/domain/orders/new/form/index.tsx
+++ b/src/domain/orders/new/form/index.tsx
@@ -1,9 +1,10 @@
-import { Region, ShippingOption } from "@medusajs/medusa"
+import { Product, Region, ShippingOption } from "@medusajs/medusa"
 import {
   useAdminRegion,
   useAdminShippingOption,
   useAdminShippingOptions,
 } from "medusa-react"
+import Medusa from "../../../../services/api"
 import React, {
   createContext,
   ReactNode,
@@ -21,6 +22,8 @@ import {
 } from "react-hook-form"
 import { AddressPayload } from "../../../../components/templates/address-form"
 import { Option } from "../../../../types/shared"
+import { PricedVariant } from "@medusajs/medusa/dist/types/pricing"
+import { extractUnitPrice } from "../../../../utils/prices"
 
 export type NewOrderForm = {
   shipping_address: AddressPayload
@@ -63,6 +66,11 @@ const NewOrderFormProvider = ({ children }: { children?: ReactNode }) => {
     },
   })
 
+  const items = useFieldArray({
+    control: form.control,
+    name: "items",
+  })
+
   const selectedRegion = useWatch({ control: form.control, name: "region" })
   const { region } = useAdminRegion(selectedRegion?.value!, {
     enabled: !!selectedRegion,
@@ -98,6 +106,38 @@ const NewOrderFormProvider = ({ children }: { children?: ReactNode }) => {
     }))
   }, [region])
 
+  useEffect(() => {
+    const updateItems = async () => {
+      if (items.fields.length) {
+        const itemsMap = items.fields.reduce((acc, next) => {
+          if (next.variant_id) {
+            acc[next.variant_id] = next
+          }
+          return acc
+        }, {} as { [key: string]: any })
+
+        const variantIds = items.fields.map((v) => v.variant_id)
+
+        const { data } = (await Medusa.variants.list({
+          id: variantIds,
+          region_id: region?.id,
+        })) as unknown as { data: { variants: PricedVariant[] } }
+
+        items.replace(
+          data.variants.map((variant) => ({
+            quantity: itemsMap[variant.id as string].quantity,
+            variant_id: variant.id,
+            title: variant.title as string,
+            unit_price: extractUnitPrice(variant, region as Region, false),
+            product_title: (variant.product as Product)?.title,
+            thumbnail: (variant.product as Product)?.thumbnail,
+          }))
+        )
+      }
+    }
+    updateItems()
+  }, [region])
+
   const { shipping_options } = useAdminShippingOptions(
     {
       region_id: region?.id,
@@ -107,11 +147,6 @@ const NewOrderFormProvider = ({ children }: { children?: ReactNode }) => {
       enabled: !!region,
     }
   )
-
-  const items = useFieldArray({
-    control: form.control,
-    name: "items",
-  })
 
   const validShippingOptions = useMemo(() => {
     if (!shipping_options) {

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -1,10 +1,4 @@
-import {
-  LineItem,
-  LineItemTaxLine,
-  MoneyAmount,
-  Order,
-  Region,
-} from "@medusajs/medusa"
+import { LineItemTaxLine, MoneyAmount, Order, Region } from "@medusajs/medusa"
 import { PricedVariant } from "@medusajs/medusa/dist/types/pricing"
 import { currencies } from "./currencies"
 


### PR DESCRIPTION
**What**
- Fix nested modal error with products page that would cause claim to fail
- Support for changing regions in draft orders

**How**
- Move price calculations for new variants to the draft order flow rather than the sub-modal products screen
- Update field array when updating quantities
- Update prices when changing regions in the new-order form

Fixes CORE-1082