### PR TITLE
fix: running effect after OE modal closes

### DIFF
--- a/src/domain/orders/edit/context.tsx
+++ b/src/domain/orders/edit/context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, PropsWithChildren } from "react"
+import React, { createContext, PropsWithChildren, useEffect } from "react"
 import { useAdminOrderEdits } from "medusa-react"
 import { OrderEdit } from "@medusajs/medusa"
 
@@ -32,6 +32,12 @@ function OrderEditProvider(props: OrderEditProviderProps) {
     order_id: orderId,
     //limit: count, // TODO
   })
+
+  useEffect(() => {
+    if (!isModalVisible) {
+      activeId = undefined
+    }
+  }, [isModalVisible])
 
   const value = {
     isModalVisible,

--- a/src/domain/orders/edit/modal.tsx
+++ b/src/domain/orders/edit/modal.tsx
@@ -418,7 +418,7 @@ function OrderEditModalContainer(props: OrderEditModalContainerProps) {
   }, [activeOrderEditId])
 
   const onClose = () => {
-    setActiveOrderEdit(undefined)
+    // setActiveOrderEdit(undefined) -> context will unset active edit after flag toggle
     hideModal()
   }
 


### PR DESCRIPTION
**What**
- I've noticed that this started to occur after we updated `react-query` recently so I presume that async flow is different now causing `activeOrderEditId` to be set to `undefined` before the last effect call in the modal is triggered. Fixed by explicitly removing active edit id after the modal is hidden.

---

FIXES CORE-1047