### PR TITLE
fix(discounts): race condition causing empty regions list to be rendered sometimes

### DIFF
--- a/src/domain/discounts/new/discount-form/sections/general.tsx
+++ b/src/domain/discounts/new/discount-form/sections/general.tsx
@@ -21,7 +21,7 @@ const General: React.FC<GeneralProps> = ({ discount }) => {
     string | undefined
   >(initialCurrency)
 
-  const { regions: opts } = useAdminRegions()
+  const { regions: opts, isLoading } = useAdminRegions()
   const { register, control, type } = useDiscountForm()
 
   const regions = useWatch({
@@ -51,20 +51,15 @@ const General: React.FC<GeneralProps> = ({ discount }) => {
     return opts?.map((r) => ({ value: r.id, label: r.name })) || []
   }, [opts])
 
-  const [render, setRender] = useState(false)
-  useEffect(() => {
-    setTimeout(() => setRender(true), 100)
-  }, [])
-
   return (
     <div className="pt-5">
-      {render && (
+      {!isLoading && (
         <>
           <Controller
             name="regions"
             control={control}
             rules={{
-              required: "Atleast one region is required",
+              required: "At least one region is required",
               validate: (value) =>
                 Array.isArray(value) ? value.length > 0 : !!value,
             }}


### PR DESCRIPTION
**What**
- logic for rendering the form with regions dropdown was relying on `setTimeout` of 100ms but in a case where a response with regions would take longer than that, an empty dropdown would be rendered

---

FIXES CORE-1099
