### PR TITLE
Fix(admin): Fix for amount not shown

### DIFF
--- a/src/domain/settings/regions/components/shipping-option-form/index.tsx
+++ b/src/domain/settings/regions/components/shipping-option-form/index.tsx
@@ -192,7 +192,7 @@ const ShippingOptionForm = ({ form, region, isEdit = false }: Props) => {
                 region.currency_code
               ),
               validate: (value) => {
-                if (!value) {
+                if (value === null) {
                   return true
                 }
 
@@ -216,7 +216,7 @@ const ShippingOptionForm = ({ form, region, isEdit = false }: Props) => {
                     }
                   />
                   <PriceFormInput
-                    amount={value || undefined}
+                    amount={typeof value === "number" ? value : undefined}
                     onChange={onChange}
                     name="requirements.min_subtotal.amount"
                     currencyCode={region.currency_code}

--- a/src/domain/settings/regions/components/shipping-option-form/index.tsx
+++ b/src/domain/settings/regions/components/shipping-option-form/index.tsx
@@ -236,7 +236,7 @@ const ShippingOptionForm = ({ form, region, isEdit = false }: Props) => {
                 region.currency_code
               ),
               validate: (value) => {
-                if (!value) {
+                if (value === null) {
                   return true
                 }
 
@@ -260,7 +260,7 @@ const ShippingOptionForm = ({ form, region, isEdit = false }: Props) => {
                     }
                   />
                   <PriceFormInput
-                    amount={value || undefined}
+                    amount={typeof value === "number" ? value : undefined}
                     onChange={onChange}
                     name="requirements.max_subtotal.amount"
                     currencyCode={region.currency_code}

--- a/src/domain/settings/regions/components/shipping-option-form/use-shipping-option-form-data.tsx
+++ b/src/domain/settings/regions/components/shipping-option-form/use-shipping-option-form-data.tsx
@@ -76,7 +76,7 @@ export const useShippingOptionFormData = (
   const getRequirementsData = (data: ShippingOptionFormType) => {
     const requirements = Object.entries(data.requirements).reduce(
       (acc, [key, value]) => {
-        if (value?.amount && value.amount > 0) {
+        if (typeof value?.amount === "number" && value.amount >= 0) {
           acc.push({
             type: key,
             amount: value.amount,

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -89,7 +89,7 @@ export function persistedPrice(currency: string, amount: number): number {
 }
 
 export const stringDisplayPrice = ({ amount, currencyCode }) => {
-  if (!amount || !currencyCode) {
+  if (typeof amount === "undefined" || !currencyCode) {
     return `N/A`
   }
 


### PR DESCRIPTION
**What**
- Ensure that 0-amounts are shown for requirements

**How**
- We validated using the amount as boolean value, however 0 is false. I added ternary checks instead of OR assignments to validate if value was a number, otherwise we use undefined. 

Fixes CORE-1075